### PR TITLE
fix: route logger StreamHandler to stdout so docker logs shows footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Rotation: 2 MB per file, 5 backups retained. Tune via `logging:` in
 - **Unraid File Manager tab** (built in since 6.12) — navigate to
   `appdata/plex-media-tiering/tier.log`, preview in-browser. Easiest for quick checks.
 - **`docker logs plex-media-tiering`** from the Docker tab → pencil icon → Log. Shows
-  the same content via the container's stream handler.
+  all INFO lines including the startup messages and the projected-tier footer.
 - **SMB share** — `\\<your-unraid-host>\appdata\plex-media-tiering\tier.log` if you
   prefer a desktop text editor.
 - **P5 future:** a small built-in HTTP log viewer exposed on a container

--- a/tier.py
+++ b/tier.py
@@ -180,7 +180,7 @@ def setup_logging(cfg: dict, quiet: bool = False) -> None:
         )
 
     if not quiet:
-        ch = logging.StreamHandler(sys.stderr)
+        ch = logging.StreamHandler(sys.stdout)
         ch.setFormatter(fmt)
         log.addHandler(ch)
 


### PR DESCRIPTION
## Summary

- `StreamHandler` in `setup_logging()` was targeting `sys.stderr`; Unraid's Docker log pane only captures stdout, so all INFO-level lines (startup messages, projected-tier footer) were absent from `docker logs` even though they appeared in `tier.log`
- Changed `sys.stderr` → `sys.stdout` — one-line fix
- Updated README wording to accurately describe what `docker logs` shows

## Test plan

- [x] Run `tier.py` locally (or in Docker) and confirm INFO lines + footer appear on stdout
- [x] Confirm `tier.log` still receives the same content (file handler unchanged)
- [x] Confirm no duplicated lines (one handler per destination)
- [x] `docker logs <container>` after a run shows startup messages AND the projected-tier footer block

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)