### PR TITLE
ci: publish branch/PR images with scoped tags on Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,10 @@
 # Builds the plex-media-tiering image and publishes to Docker Hub.
 #
 # Triggers:
-#   - push to main         -> :main  + :latest (movable tag)
-#   - tag v*.*.*           -> :1.2.3 + :1.2    + :1 + :latest  (semver)
+#   - push to main         -> :latest + :main + :sha-<short>
+#   - push to other branch -> :<branch> + :sha-<short>
+#   - pull request (same-repo) -> :pr-<N> + :sha-<short>  (fork PRs: build only, no push)
+#   - tag v*.*.*           -> :1.2.3 + :1.2 + :1 + :latest + :sha-<short>
 #   - manual (workflow_dispatch) -> whatever branch/tag you pick
 #
 # Unraid's Community Applications updater polls the image digest of the
@@ -22,8 +24,10 @@ name: docker-publish
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
     tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -52,11 +56,12 @@ jobs:
           images: ${{ steps.img.outputs.image }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,format=short
           labels: |
             org.opencontainers.image.title=plex-media-tiering
             org.opencontainers.image.description=Unraid media tiering script (Plex-driven, hot/warm ZFS + array)
@@ -70,12 +75,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/README.md
+++ b/README.md
@@ -153,11 +153,26 @@ GitHub Actions is free on public repos. The workflow builds multi-arch
   touching your account password.
 
 **Tagging strategy:**
-- `:latest` and `:main` — moving tags, auto-updated on every main push.
-  Fine for "track tip-of-branch" during development.
+
+| Event | Tags produced |
+| --- | --- |
+| Push to `main` | `:latest`, `:main`, `:sha-<short>` |
+| Push to other branch (e.g. `dev`) | `:<branch>`, `:sha-<short>` |
+| Pull request (same-repo) | `:pr-<N>`, `:sha-<short>` |
+| Git tag `v1.2.3` | `:1.2.3`, `:1.2`, `:1`, `:latest`, `:sha-<short>` |
+
+- `dazzathewiz/plex-media-tiering:latest` — stable, built from `main`.
+  Point Unraid CA here for rolling updates.
+- `dazzathewiz/plex-media-tiering:pr-<N>` — per-PR test image, useful for
+  manually testing a fix before merging.
+- `dazzathewiz/plex-media-tiering:dev` — rolling dev branch tip, if you
+  push a `dev` branch.
 - `:1.2.3` / `:1.2` / `:1` — created by pushing a `v1.2.3` git tag.
   Point CA at `:1` for patch+minor auto-updates without breaking
   changes.
+
+Fork PRs (external contributors): the workflow builds the image for CI
+validation but does not push to Docker Hub (secrets unavailable).
 
 ## Logging
 


### PR DESCRIPTION
Add pull_request trigger and widen push to all branches so non-main work produces usable test images. Tag matrix:
  push main          → :latest :main :sha-<short>
  push other branch  → :<branch> :sha-<short>
  PR (same-repo)     → :pr-<N> :sha-<short>
  semver tag         → :1.2.3 :1.2 :1 :latest :sha-<short>

Add type=ref,event=pr and fix sha prefix to sha- (was unprefixed). Gate login + build-push on same-repo check so fork PRs build but don't attempt a push (secrets unavailable).

Update README tagging strategy with a full tag-matrix table and per-image descriptions for :latest, :pr-<N>, and :dev.