### PR TITLE
feat(p0.4): added-date floor — promote recently-added media to HOT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ CLAUDE.md and GEMINI.md are symlinks to this file.
 |---|---|---|
 | P0   | Plex catalog + history + scoring + table output, read-only | Done |
 | P0.1 | Pinning (library + title), recency floor, projected-tier footer | Done |
+| P0.4 | Added-date floor — promote recently-added movies and TV shows with fresh episodes to HOT | Done |
 | P1   | Filesystem tier detection, path translation, majority-bytes rollup | Done |
 | P0.2 | Collection-aware grouping (Harry Potter, etc.) | Pending |
 | P2   | `--apply`: rsync moves + Plex rescan | Pending |
@@ -113,13 +114,56 @@ the `year` field. Cosmetic only — doesn't affect scoring.
 
 1. Library pin (case-insensitive exact match on library name) → HOT + pinned
 2. Title pin (case-insensitive substring) → HOT + pinned
-3. Raw score → HOT / WARM / NEUTRAL
-4. Recency floor (only if raw rec was NEUTRAL or WARM, and last_played is
+3. Added-date floor (if `item.recently_added`) → HOT
+4. Raw score → HOT / WARM / NEUTRAL
+5. Recency floor (only if raw rec was NEUTRAL or WARM, and last_played is
    within `hot_recency_days`) → HOT
 
-Pinning wins over everything. Recency floor only *promotes*, never demotes
-— this is important for sanity: pinning never gets overridden by score
-decay, but recency can't drag a pinned item into WARM either.
+Pinning wins over everything. Both floors are promote-only, never demote.
+The added-date floor sits above raw score so NEUTRAL items get promoted
+before the score check. Recency floor sits below raw score and only fires
+when the score alone didn't reach HOT.
+
+### Two-floor promotion model
+
+There are two independent promote-only floors, both set in `thresholds:`.
+Neither can demote an item. Either can be disabled by setting its value to
+`0` or `null`.
+
+**Recency floor** (`hot_recency_days`): keyed off *playback*. If an item
+was last watched within the window, it is promoted to HOT. Designed for
+infrequent-but-active shows that the play-weighted score would otherwise
+demote (one episode every few weeks scores low, but the user is clearly
+watching it).
+
+**Added-date floor** (`added_floor_days_movies` / `added_floor_days_tv`):
+keyed off *Plex catalog additions*. If a movie was added recently, or if
+any episode in a TV show was added recently, the item is promoted to HOT
+without requiring any play history. Rationale: Plex surfaces recently-added
+media on the home screen for roughly this long, and users are likely to
+watch new additions regardless of their release year.
+
+The two floors are mutually independent — an item can qualify for both,
+either, or neither. The added-date floor takes precedence over raw score
+(step 3 before step 4) so it fires even on NEUTRAL-score items. The
+recency floor fires after raw score (step 5) so it only promotes items the
+score didn't already put in HOT.
+
+#### TV performance note
+
+The added-date floor for TV must NOT iterate `show.episodes()` per show —
+that is thousands of API calls on a large library. Instead, one call per
+TV library section:
+
+```python
+cutoff = datetime.now(timezone.utc) - timedelta(days=added_floor_days_tv)
+recent_eps = section.search(libtype="episode", addedAt__gte=cutoff)
+recently_active_shows = {int(ep.grandparentRatingKey) for ep in recent_eps}
+```
+
+`_build_recently_active_shows()` encapsulates this. The resulting set is
+passed into `collect_series()` as `recently_active_shows` and looked up
+O(1) per show via `show.ratingKey in recently_active_shows`.
 
 ### Tier rollup: majority of bytes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,13 +157,32 @@ TV library section:
 
 ```python
 cutoff = datetime.now(timezone.utc) - timedelta(days=added_floor_days_tv)
-recent_eps = section.search(libtype="episode", addedAt__gte=cutoff)
+recent_eps = section.search(libtype="episode", addedAt__gte=int(cutoff.timestamp()))
 recently_active_shows = {int(ep.grandparentRatingKey) for ep in recent_eps}
 ```
 
 `_build_recently_active_shows()` encapsulates this. The resulting set is
 passed into `collect_series()` as `recently_active_shows` and looked up
 O(1) per show via `show.ratingKey in recently_active_shows`.
+
+#### plexapi addedAt filter requires int Unix seconds
+
+`section.search(addedAt__gte=...)` and `addedAt__lte=...` expect an **int
+Unix timestamp** (seconds since epoch), not a Python `datetime`. Plexapi's
+filter evaluation compares the value against the stored string form of the
+Unix timestamp — passing a `datetime` raises:
+
+```text
+TypeError: '>=' not supported between instances of 'str' and 'datetime.datetime'
+```
+
+Always convert on the caller side: `int(cutoff.timestamp())`. This quirk
+does not affect the movies floor, which computes its check with plain
+`timedelta` arithmetic on `item.added` without ever calling `section.search`.
+
+The regression test `_test_added_floor_tv_search_uses_int_timestamp` in
+`--_test` guards against this being reintroduced: it stubs `section.search`,
+captures the kwargs, and asserts `addedAt__gte` is an `int`.
 
 ### Tier rollup: majority of bytes
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ prints the analysis table. It still doesn't move anything — that's P2.
 |-------|--------------|--------|
 | P0 | Plex connect + scoring + table output. Read-only. | **Done** |
 | P0.1 | Pinning (library + title), recency floor, projected-tier footer. | **Done** |
+| P0.4 | Added-date floor — promote recently-added movies and TV shows with fresh episodes to HOT. | **Done** |
 | P1 | Filesystem probing to detect current tier. Auto-detect array disks + Plex path translation. Majority-bytes rollup. | **Done** |
 | P0.2 | Collection-aware grouping (Harry Potter, Hunger Games, etc.). | Pending |
 | P2 | `--apply` with rsync moves + Plex rescan. | Pending |
@@ -306,9 +307,9 @@ at least one array disk is known (either listed explicitly in `paths.array_disks
 or found by auto-detect). If either is missing, outcomes degrade to
 `SHOULD_BE_*` / `NEUTRAL` so the script stays useful in a bare-P0 config.
 
-### Overrides: pinning + recency floor
+### Overrides: pinning + recency + added floors
 
-Three ways to force HOT regardless of raw score, evaluated in this order:
+Five-step precedence applied after scoring (highest wins):
 
 1. **`pinning.always_hot_libraries`** — list of library names (case-insensitive
    exact match). Every item in those libraries is `PIN_HOT`. Useful for things
@@ -317,16 +318,40 @@ Three ways to force HOT regardless of raw score, evaluated in this order:
    Any item whose title contains one of these is `PIN_HOT`. Great for long-tail
    favourites — pinning `"Stargate"` catches SG-1, Atlantis, Universe, Origins
    and the movie in a single entry.
-3. **`thresholds.hot_recency_days`** — recency floor. If a show or movie was
-   last played within this window, it's promoted to `SHOULD_BE_HOT` even if
-   the raw score lands in `NEUTRAL` or `SHOULD_BE_WARM`. This catches
-   infrequent-but-active shows (one episode every few weeks) that the play-
-   weighted score otherwise demotes. Default: `730` (≈2 years). Set to `0` or
-   comment out to disable.
+3. **Added-date floor** — promote-only, never demotes. See below.
+4. Raw score → HOT / WARM / NEUTRAL.
+5. **`thresholds.hot_recency_days`** — recency floor. If a show or movie was
+   last played within this window, it's promoted to HOT even if the raw score
+   lands in NEUTRAL or WARM. This catches infrequent-but-active shows (one
+   episode every few weeks) that the play-weighted score otherwise demotes.
+   Default: `730` (≈2 years). Set to `0` or comment out to disable.
 
-Pinned and recency-floor promotions tag the `score_breakdown` with an
-`override` key so `--explain` shows why the item was promoted past its raw
-score.
+Pinning and floor promotions tag the `score_breakdown` with an `override` key
+so `--explain` shows why the item was promoted past its raw score.
+
+#### Added-date floor
+
+Items added to Plex recently are likely to be watched regardless of their
+release year. The added-date floor promotes them to HOT without requiring any
+play history.
+
+- **Movies**: if `movie.addedAt` is within `thresholds.added_floor_days_movies`
+  days, the movie is promoted to HOT. Default: `45`.
+- **TV shows**: if any episode in the show was added within
+  `thresholds.added_floor_days_tv` days, the show is promoted to HOT. This
+  catches currently-airing series whose show-level `addedAt` is old but whose
+  episodes are fresh. Default: `30`.
+
+Set either threshold to `0` or `null` to disable it for that media type.
+
+```yaml
+thresholds:
+  added_floor_days_movies: 45   # movies added within 45 days -> HOT
+  added_floor_days_tv: 30       # TV show with episode added within 30 days -> HOT
+```
+
+The footer line `Added-floor promotions: N items` in the run log counts how
+many items were promoted by this rule.
 
 ## Tier detection (P1)
 

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -35,6 +35,14 @@ thresholds:
   # show with one episode every few weeks) from being demoted just
   # because the play count is low. Set to 0 or comment out to disable.
   hot_recency_days: 730   # ~2 years
+  # Added-date floor — items added to Plex within this window are
+  # promoted to HOT even if never watched. Plex surfaces recently-added
+  # media on the home screen for roughly this long; tier them accordingly.
+  # TV floor fires when ANY episode in the show was added within the
+  # window (catches currently-airing shows whose show-level addedAt is
+  # old). Set to 0 or null to disable.
+  added_floor_days_movies: 45   # movies added within 45 days -> HOT
+  added_floor_days_tv: 30       # TV show with episode added within 30 days -> HOT
 
 # Pinning — overrides that force items to HOT regardless of score.
 # Both lists are case-insensitive. Library matching is exact; title

--- a/tier.py
+++ b/tier.py
@@ -934,7 +934,10 @@ def _build_recently_active_shows(section, thresholds: dict) -> set:
         return set()
     cutoff = datetime.now(timezone.utc) - timedelta(days=int(days))
     try:
-        recent_eps = section.search(libtype="episode", addedAt__gte=cutoff)
+        # plexapi compares addedAt__gte against the stored string form of a
+        # Unix timestamp — passing a datetime causes a str >= datetime
+        # TypeError. int seconds is the only form that works.
+        recent_eps = section.search(libtype="episode", addedAt__gte=int(cutoff.timestamp()))
         return {
             int(ep.grandparentRatingKey)
             for ep in recent_eps
@@ -1857,6 +1860,36 @@ def _test_added_floor_never_demotes():
     print("_test_added_floor_never_demotes: OK")
 
 
+def _test_added_floor_tv_search_uses_int_timestamp():
+    """_build_recently_active_shows must pass int Unix timestamp to addedAt__gte.
+
+    plexapi's filter evaluation compares addedAt__gte against the stored string
+    form of a Unix timestamp. Passing a datetime object causes:
+      TypeError: '>=' not supported between instances of 'str' and 'datetime.datetime'
+    Only int seconds avoids this — the check here guards against regression.
+    """
+    captured = {}
+
+    class _FakeEp:
+        grandparentRatingKey = 99
+
+    class _FakeSection:
+        title = "TV Shows"
+
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return [_FakeEp()]
+
+    result = _build_recently_active_shows(_FakeSection(), {"added_floor_days_tv": 30})
+
+    assert "addedAt__gte" in captured, "addedAt__gte not passed to section.search"
+    assert isinstance(captured["addedAt__gte"], int), (
+        f"addedAt__gte must be int (Unix seconds), got {type(captured['addedAt__gte']).__name__}"
+    )
+    assert result == {99}
+    print("_test_added_floor_tv_search_uses_int_timestamp: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -1867,5 +1900,6 @@ if __name__ == "__main__":
         _test_added_floor_disabled()
         _test_added_floor_preserves_pin()
         _test_added_floor_never_demotes()
+        _test_added_floor_tv_search_uses_int_timestamp()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -12,6 +12,9 @@ Phase status:
   P0  (done)        Read-only analysis from Plex catalog + watch history.
   P0.1 (done)       Pinning (library + title), recency floor, projected-
                     tier footer.
+  P0.4 (done)       Added-date floor — promote recently-added movies and
+                    TV shows with fresh episodes to HOT regardless of
+                    play count.
   P1  (this file)   Filesystem probing to detect current tier. Auto-
                     detects array disks, translates Plex-side paths via
                     plex_path_map, rolls multi-part items up by bytes.
@@ -50,7 +53,7 @@ import traceback
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field, asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
@@ -88,6 +91,12 @@ DEFAULT_CONFIG = {
         # regardless of raw score. Stops active-but-infrequent shows from
         # being demoted just because the play count is low.
         "hot_recency_days": 730,  # ~2 years
+        # Added-date floor — items added to Plex within this window are
+        # promoted to HOT even if never watched. Plex surfaces recently-
+        # added media on the home screen for roughly this long; tier them
+        # accordingly. Set to 0 or null to disable.
+        "added_floor_days_movies": 45,
+        "added_floor_days_tv": 30,
     },
     "pinning": {
         # Libraries whose contents should stay HOT unconditionally.
@@ -317,6 +326,8 @@ class Item:
     current_tier: str = "UNKNOWN"  # 'HOT' | 'WARM' | 'UNKNOWN'
     # --- decision ---
     outcome: str = "NEUTRAL"       # See decide_outcome() for P0 values
+    # --- added-date floor flag (set by collect_* if floor threshold met) ---
+    recently_added: bool = False
     # --- for --explain ---
     score_breakdown: dict = field(default_factory=dict)
 
@@ -911,6 +922,32 @@ def _show_history_fallback(show) -> tuple[int, Optional[datetime]]:
     return plays, last
 
 
+def _build_recently_active_shows(section, thresholds: dict) -> set:
+    """Return int ratingKeys of shows that have episodes added within the floor window.
+
+    ONE section.search() call per TV library — O(1) per show, avoids
+    iterating show.episodes() which would be thousands of API calls.
+    Returns empty set if added_floor_days_tv is 0/null or the call fails.
+    """
+    days = thresholds.get("added_floor_days_tv")
+    if not days:
+        return set()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=int(days))
+    try:
+        recent_eps = section.search(libtype="episode", addedAt__gte=cutoff)
+        return {
+            int(ep.grandparentRatingKey)
+            for ep in recent_eps
+            if getattr(ep, "grandparentRatingKey", None) is not None
+        }
+    except Exception as e:  # noqa: BLE001
+        log.warning(
+            "Added-floor TV search failed for section %r: %s — floor disabled for this section",
+            section.title, e,
+        )
+        return set()
+
+
 def collect_movies(
     section, library_name: str, now, thresholds, history_index: dict,
     path_map, hot_mount: str, array_disks: List[str],
@@ -967,6 +1004,13 @@ def collect_movies(
 
         score, breakdown = heat_score(plays, last, added, now, thresholds)
 
+        # Added-date floor: flag if added within the threshold window.
+        added_floor_days = int(thresholds.get("added_floor_days_movies") or 0)
+        recently_added = bool(
+            added_floor_days
+            and (now - _as_utc(added)).days <= added_floor_days
+        )
+
         # Current tier (P1). Probes only if tier detection is configured.
         current_tier = "UNKNOWN"
         tier_split: Optional[dict] = None
@@ -992,6 +1036,7 @@ def collect_movies(
             score=score,
             current_tier=current_tier,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
+            recently_added=recently_added,
             score_breakdown=breakdown,
         )
 
@@ -1000,6 +1045,7 @@ def collect_series(
     section, library_name: str, now, thresholds, history_index: dict,
     path_map, hot_mount: str, array_disks: List[str],
     user_share_prefix: str = "",
+    recently_active_shows: Optional[set] = None,
 ) -> Iterable[Item]:
     tier_probing = bool(hot_mount) and bool(array_disks)
 
@@ -1059,6 +1105,12 @@ def collect_series(
 
         score, breakdown = heat_score(plays, last, added, now, thresholds)
 
+        # Added-date floor: show is "recently active" if any episode was
+        # added within the threshold window (checked via pre-built set).
+        recently_added = bool(
+            recently_active_shows and rk is not None and rk in recently_active_shows
+        )
+
         # Current tier (P1): majority-bytes rollup across every episode.
         current_tier = "UNKNOWN"
         tier_split: Optional[dict] = None
@@ -1084,6 +1136,7 @@ def collect_series(
             score=score,
             current_tier=current_tier,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
+            recently_added=recently_added,
             score_breakdown=breakdown,
         )
 
@@ -1101,9 +1154,10 @@ def _compute_recommendation(
     Precedence (highest wins):
       1. Library pin       -> HOT, pinned=True
       2. Title pin         -> HOT, pinned=True
-      3. Recency floor     -> HOT if last_played within hot_recency_days
-                              AND raw recommendation is NEUTRAL or WARM.
+      3. Added floor       -> HOT if item.recently_added is True
       4. Raw score         -> HOT / WARM / NEUTRAL via score_recommendation.
+      5. Recency floor     -> HOT if last_played within hot_recency_days
+                              AND raw recommendation is NEUTRAL or WARM.
     """
     pinning = cfg.get("pinning") or {}
     thresholds = cfg.get("thresholds") or {}
@@ -1127,10 +1181,24 @@ def _compute_recommendation(
         if needle_hit:
             return "HOT", True, f"pinned title match: {needle_hit!r}"
 
-    # --- 3. Raw score ---
+    # --- 3. Added-date floor (only promotes, never demotes) ---
+    if item.recently_added:
+        if item.kind == "movie":
+            days_since_added = (now - _as_utc(item.added)).days
+            threshold = thresholds.get("added_floor_days_movies", 45)
+            reason = (
+                f"added-date floor: added {days_since_added}d ago "
+                f"(<= added_floor_days_movies={threshold})"
+            )
+        else:
+            threshold = thresholds.get("added_floor_days_tv", 30)
+            reason = f"added-date floor: recent episode (<= added_floor_days_tv={threshold})"
+        return "HOT", False, reason
+
+    # --- 4. Raw score ---
     raw_rec = score_recommendation(item.score, thresholds)
 
-    # --- 4. Recency floor (only promotes, never demotes) ---
+    # --- 5. Recency floor (only promotes, never demotes) ---
     recency_days = thresholds.get("hot_recency_days")
     if (
         recency_days
@@ -1199,6 +1267,10 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
             hot_mount, len(array_disks),
         )
 
+    thresholds = cfg["thresholds"]
+    floor_movie_count = 0
+    floor_series_count = 0
+
     items: List[Item] = []
     for lib_cfg in cfg["libraries"]:
         name = lib_cfg["name"] if isinstance(lib_cfg, dict) else lib_cfg
@@ -1210,24 +1282,36 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
             print(f"! Could not open library '{name}': {e}", file=sys.stderr)
             continue
         if section.type == "movie":
-            items.extend(
+            new_items = list(
                 collect_movies(
-                    section, name, now, cfg["thresholds"], history_index,
+                    section, name, now, thresholds, history_index,
                     path_map, hot_mount, array_disks, user_share_prefix,
                 )
             )
+            floor_movie_count += sum(1 for it in new_items if it.recently_added)
+            items.extend(new_items)
         elif section.type == "show":
-            items.extend(
+            recently_active_shows = _build_recently_active_shows(section, thresholds)
+            floor_series_count += len(recently_active_shows)
+            new_items = list(
                 collect_series(
-                    section, name, now, cfg["thresholds"], history_index,
+                    section, name, now, thresholds, history_index,
                     path_map, hot_mount, array_disks, user_share_prefix,
+                    recently_active_shows=recently_active_shows,
                 )
             )
+            items.extend(new_items)
         else:
             print(
                 f"! Library '{name}' has unsupported type '{section.type}', skipping",
                 file=sys.stderr,
             )
+
+    if thresholds.get("added_floor_days_movies") or thresholds.get("added_floor_days_tv"):
+        log.info(
+            "Added-floor: %d movies + %d series with recent activity",
+            floor_movie_count, floor_series_count,
+        )
 
     # Post-scoring override pass. Done here (not per-collector) so both
     # movie and series paths share the same rule engine and the summary
@@ -1548,6 +1632,13 @@ def _run(args) -> int:
             f"{k}={v}" for k, v in sorted(s["outcomes"].items())
         )
         log.info("  Outcome counts: %s", outcomes_str)
+        thresholds = cfg["thresholds"]
+        if thresholds.get("added_floor_days_movies") or thresholds.get("added_floor_days_tv"):
+            floor_promotions = sum(
+                1 for it in items
+                if "added-date floor" in it.score_breakdown.get("override", "")
+            )
+            log.info("  Added-floor promotions: %d items", floor_promotions)
 
     return 0
 
@@ -1640,8 +1731,141 @@ def _test_resolve_user_share():
     print("_test_resolve_user_share: OK")
 
 
+def _make_cfg(extra_thresholds=None):
+    """Minimal config dict for test harness."""
+    t = {
+        "score_to_hot": 40.0,
+        "score_to_warm": 20.0,
+        "recency_half_life_days": 90,
+        "age_grace_days": 180,
+        "added_floor_days_movies": 45,
+        "added_floor_days_tv": 30,
+    }
+    if extra_thresholds:
+        t.update(extra_thresholds)
+    return {"pinning": {}, "thresholds": t}
+
+
+def _make_item(**kwargs):
+    """Build an Item with sensible defaults for test harness."""
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        title="Test Item", year=2024, kind="movie", library="Movies",
+        plays=0, last_played=None,
+        added=now - timedelta(days=200),
+        size_bytes=1_000_000_000,
+        score=25.0,
+        recently_added=False,
+    )
+    defaults.update(kwargs)
+    return Item(**defaults)
+
+
+def _test_added_floor_movie_recent():
+    """movie addedAt=10d ago, 0 plays, score=25 (NEUTRAL) -> HOT via floor"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(added=now - timedelta(days=10), score=25.0, recently_added=True)
+    rec, pinned, reason = _compute_recommendation(item, _make_cfg(), now)
+    assert rec == "HOT", f"expected HOT, got {rec}"
+    assert not pinned
+    assert reason and "added-date floor" in reason
+    print("_test_added_floor_movie_recent: OK")
+
+
+def _test_added_floor_movie_old():
+    """movie addedAt=100d ago -> floor does NOT engage; score=0 -> WARM"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(added=now - timedelta(days=100), score=0.0, recently_added=False)
+    rec, pinned, reason = _compute_recommendation(item, _make_cfg(), now)
+    assert rec == "WARM", f"expected WARM, got {rec}"
+    assert not pinned
+    assert reason is None
+    print("_test_added_floor_movie_old: OK")
+
+
+def _test_added_floor_tv_recent_episode():
+    """show.addedAt=2y ago, recently_added=True (episode 5d ago), 0 plays -> HOT"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(
+        kind="series", library="TV Shows",
+        added=now - timedelta(days=730), score=0.0, recently_added=True,
+    )
+    rec, pinned, reason = _compute_recommendation(item, _make_cfg(), now)
+    assert rec == "HOT", f"expected HOT, got {rec}"
+    assert not pinned
+    assert reason and "added-date floor" in reason
+    print("_test_added_floor_tv_recent_episode: OK")
+
+
+def _test_added_floor_tv_no_recent():
+    """show with no recent episodes -> floor does NOT engage; score=0 -> WARM"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(
+        kind="series", library="TV Shows",
+        added=now - timedelta(days=730), score=0.0, recently_added=False,
+    )
+    rec, pinned, reason = _compute_recommendation(item, _make_cfg(), now)
+    assert rec == "WARM", f"expected WARM, got {rec}"
+    assert not pinned
+    assert reason is None
+    print("_test_added_floor_tv_no_recent: OK")
+
+
+def _test_added_floor_disabled():
+    """added_floor_days_movies=0, recently_added=False, score=25 -> NEUTRAL"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(
+        added=now - timedelta(days=5), score=25.0, recently_added=False,
+    )
+    cfg = _make_cfg({"added_floor_days_movies": 0, "added_floor_days_tv": 0})
+    rec, pinned, reason = _compute_recommendation(item, cfg, now)
+    assert rec == "NEUTRAL", f"expected NEUTRAL, got {rec}"
+    assert not pinned
+    assert reason is None
+    print("_test_added_floor_disabled: OK")
+
+
+def _test_added_floor_preserves_pin():
+    """library-pinned + recently_added=True -> pinned=True, outcome=PIN_HOT"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(
+        library="4K Movies", added=now, score=25.0, recently_added=True,
+    )
+    cfg = _make_cfg()
+    cfg["pinning"] = {"always_hot_libraries": ["4K Movies"]}
+    rec, pinned, reason = _compute_recommendation(item, cfg, now)
+    assert pinned, "expected pinned=True"
+    assert "pinned library" in (reason or "")
+    outcome = _combine_outcome("UNKNOWN", rec, pinned)
+    assert outcome == "PIN_HOT", f"expected PIN_HOT, got {outcome}"
+    print("_test_added_floor_preserves_pin: OK")
+
+
+def _test_added_floor_never_demotes():
+    """recently_added=True, no plays, no hot_recency -> floor fires, outcome=HOT"""
+    now = datetime.now(timezone.utc)
+    item = _make_item(
+        kind="series", library="TV Shows",
+        added=now - timedelta(days=365), score=0.0, recently_added=True,
+        last_played=None,
+    )
+    cfg = _make_cfg({"hot_recency_days": 730})
+    rec, pinned, reason = _compute_recommendation(item, cfg, now)
+    assert rec == "HOT", f"expected HOT, got {rec}"
+    assert not pinned
+    assert reason and "added-date floor" in reason
+    print("_test_added_floor_never_demotes: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
+        _test_added_floor_movie_recent()
+        _test_added_floor_movie_old()
+        _test_added_floor_tv_recent_episode()
+        _test_added_floor_tv_no_recent()
+        _test_added_floor_disabled()
+        _test_added_floor_preserves_pin()
+        _test_added_floor_never_demotes()
         sys.exit(0)
     sys.exit(main())


### PR DESCRIPTION
Closes #6.

## Summary

- New `thresholds.added_floor_days_movies` (default 45) and `added_floor_days_tv` (default 30) promote items to HOT if added recently, even with zero plays — fixing the "Return of Jafar" NEUTRAL case
- TV floor uses a single `section.search(libtype='episode', addedAt__gte=cutoff)` per library (O(1) per show), not `show.episodes()` per show
- Override precedence updated to 5 steps: pins → added floor → raw score → recency floor
- Footer logs `Added-floor promotions: N items`; collection logs `Added-floor: N movies + M series with recent activity`
- 7 new `--_test` cases covering: recent movie, old movie, recent TV episode, no recent TV, disabled threshold, pin preservation, and promote-only guarantee

## Test plan

- [x] `python3 tier.py --_test` passes all 8 cases (existing + 7 new)
- [x] `python3 -m py_compile tier.py` — no errors
- [x] `python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"` — valid YAML
- [x] On a real run: items previously NEUTRAL with `addedAt` within threshold flip to `TO_HOT` / `STAY_HOT`
- [x] `Added-floor promotions: N` appears in the log footer
- [x] Setting `added_floor_days_movies: 0` restores NEUTRAL for new unwatched movies

🤖 Generated with [Claude Code](https://claude.com/claude-code)