### PR TITLE
ci: add test workflow (py_compile + YAML validity + --_test)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Compile check
+        run: python3 -m py_compile tier.py
+      - name: YAML validity
+        run: |
+          python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
+      - name: Inline test harness
+        run: python3 tier.py --_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,16 @@ revocation event, not a quick fix.
 
 ### Before committing
 
+#### Automated in CI
+
+Every push and pull request targeting `main` runs `.github/workflows/test.yml`,
+which executes the three checks below automatically. A failing check blocks
+PR merge (once branch protection is enabled). You do not need to run these
+as a manual ritual, but running them locally first gives a fast-fail loop
+before waiting for CI.
+
+#### Run locally before pushing
+
 ```bash
 # 1. Compile check
 python3 -m py_compile tier.py
@@ -250,9 +260,8 @@ python3 -m py_compile tier.py
 # 2. YAML validity
 python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
 
-# 3. No personal info leaking back in
-grep -iE "your|personal|information" tier.py example.tiering.yaml README.md
-#    should return nothing
+# 3. Inline test harness
+python3 tier.py --_test
 ```
 
 When adding non-trivial logic (scoring tweak, new outcome, path handling),


### PR DESCRIPTION
Closes #8.

## Summary

- New `.github/workflows/test.yml` runs on every push/PR to `main`: `py_compile`, YAML validity check, and `python3 tier.py --_test`
- `docker-publish.yml` untouched — test and build concerns stay separate
- AGENTS.md "Before committing" reorganised: new **Automated in CI** subsection explains what CI does and why local runs are still useful for fast-fail; **Run locally before pushing** retains the three commands with `--_test` replacing the removed grep (which matched on personal strings)

## Test plan

- [ ] Workflow file is valid YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`)
- [ ] CI run on this PR passes all three steps
- [ ] `docker-publish.yml` diff is empty (untouched)
- [ ] AGENTS.md renders correctly — no new linting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)