### PR TITLE
docs(P0.5): document dominant-disk majority-bytes rollup for Item.current_disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,20 @@ tier.py knows about, so targeting it would be unsafe.
 projected-WARM size total includes items that will relocate within the warm
 tier. They are NOT leaving the warm tier, just changing disks within it.
 
+**Dominant warm disk rollup (`Item.current_disk`).** TV series commonly
+span multiple array disks (older seasons on one, newer on another).
+The eviction pass needs to attribute a series to exactly one disk. The
+chosen rule is **majority bytes**: whichever array disk holds the most
+bytes of the item wins and is stored as `Item.current_disk`. Consequences:
+
+- An item with only a small minority of bytes on an evicting disk does
+  **not** trigger `RELOCATE_WARM` — if 90% of a series is on disk1 and
+  10% on disk7, evicting disk7 does not justify moving the whole series.
+- `Item.current_disk` is only populated when `current_tier == "WARM"`.
+  HOT items don't get one — there is no per-disk concept on the ZFS pool.
+- Do not refactor to "first disk found" or a list of all disks containing
+  the item. The majority-bytes winner is intentional.
+
 ### Graceful degradation
 
 Tier detection activates only when BOTH `paths.hot_pool_mount` is set AND


### PR DESCRIPTION
Doc-only follow-up to #15 (P0.5 disk eviction).

## What

Extends the existing P0.5 design block in `AGENTS.md` with the rationale for how `Item.current_disk` is populated — why `resolve_item_current_tier` uses **majority bytes** to attribute a multi-disk item to one disk, and what that means for eviction triggering.

## Why

The dominant-disk rollup is non-obvious. TV series whose episodes span multiple array disks need a single-disk attribution for eviction. The choices were:
- first disk found (wrong: arbitrary, order-dependent)
- list of all disks (wrong: eviction pass would need per-disk logic)
- majority bytes (chosen: consistent with the tier-rollup already in the function)

Without this note, a future agent seeing a loop over `array_disks` that picks the max might "simplify" it to a first-match or flatten it to a set.

## Changes

`AGENTS.md` only — 14 lines added, zero code/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)