### PR TITLE
feat(P2.1): move executor — TO_HOT direction with --apply gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ re-litigate (and get wrong) from reading the diff alone.
 
 A single-file Python script (`tier.py`) that asks Plex which media is
 hot/cold, probes the local filesystem to see where each item currently
-lives, and recommends where it *should* live — on a fast pool (HOT) or a
-parity array (WARM). Phased design; it refuses to actually move anything
-until P2 ships.
+lives, and recommends — and now executes — moves between a fast pool (HOT)
+and a parity array (WARM). Move execution is opt-in (`moves.enabled: true`
++ `--apply`); dry-run is the default.
 
 Runs as a one-shot Docker container scheduled by Unraid's User Scripts
 plugin. Image is built by GitHub Actions on every push to `main`, multi-
@@ -45,7 +45,9 @@ CLAUDE.md and GEMINI.md are symlinks to this file.
 | P0.4 | Added-date floor — promote recently-added movies and TV shows with fresh episodes to HOT | Done |
 | P0.5 | Disk eviction mode — mark warm-tier array disks as evicting; items on them get RELOCATE_WARM. Data model + reporting only; actual moves are P2 | Done |
 | P1   | Filesystem tier detection, path translation, majority-bytes rollup | Done |
-| P2   | `--apply`: rsync moves + Plex rescan | Pending |
+| P2.1 | Move executor — TO_HOT direction; rsync + size-verify + source delete; parity guard; dry-run by default | Done |
+| P2.2 | TO_WARM + RELOCATE_WARM moves | Pending |
+| P2.3 | Plex rescan automation post-move | Pending |
 | P3   | Hardening: lock file, currently-playing skip, free-space check, move cap | Pending |
 | P4   | Scheduled cron + size-triggered wrapper | Pending |
 
@@ -386,6 +388,54 @@ unaffected. If a file doesn't exist on any probed mount the original
 (unresolved) path is returned and `classify_path()` marks it UNKNOWN,
 preserving graceful degradation.
 
+### Move executor (P2.1)
+
+**Why TO_HOT is shipped first (lowest-risk direction).**
+The source is the parity-protected Unraid array; the destination is a separate
+ZFS pool with no redundancy contract with the source. A failed move doesn't
+reduce redundancy — the source is parity-protected until we explicitly delete
+it post-verification. There is also no destination-disk selection problem (the
+ZFS pool is a single target). This makes TO_HOT the cleanest first cut without
+importing P3's free-space-budget complexity.
+
+**Why source deletion is gated on size-verify.**
+Silent data loss is the worst possible failure mode for a file mover. rsync
+exiting 0 doesn't guarantee a complete transfer — disk-full conditions, network
+interruptions, or corruption can leave a truncated destination. The size-verify
+step (`du -sb` on source and destination, tolerance ≤ 1 KB) is the only safety
+gate between a failed rsync and a deleted source. Never bypass it to save time.
+
+**Why moves are serial, not parallel.**
+Parallel rsyncs against a parity-protected Unraid array thrash the parity disk
+and can cause I/O contention that degrades both array performance and parity
+integrity. The throughput gain from parallelism is marginal compared to the risk.
+P2.2 will revisit if operators request it, with explicit caveats.
+
+**Why parity check is a blocker, not a warning.**
+Unraid's parity recalculation reads every data block and recomputes expected
+parity. A concurrent write (which rsync produces) changes a block after parity
+has been sampled, leaving the array with a parity mismatch for that stripe.
+This is silent unless the next parity check reveals it. Aborting the move pass
+before any rsync call is the only safe behaviour. The `parity_check_blocking:
+false` escape hatch exists for operators who understand the risk and have a
+specific reason to proceed.
+
+**Why `[SKIPPED]` for already-HOT items is an idempotency net.**
+If the script is re-run after a partial apply, some TO_HOT items may have
+already arrived on the hot pool (because rsync succeeded but the run was
+interrupted before the summary logged). Detecting `current_tier == HOT` on a
+TO_HOT item and logging SKIPPED instead of re-rsyncing is a cheap idempotency
+guard that prevents double-rsyncing. It does not indicate a scoring error.
+
+**`Item.source_dir` — common-ancestor directory of files on dominant disk.**
+`resolve_item_current_tier()` now returns a fourth value: the common ancestor
+directory of all resolved file paths on the dominant WARM disk. For a single
+movie file at `/mnt/disk4/Movies/Foo/foo.mkv` it is the parent directory
+`/mnt/disk4/Movies/Foo`. For a TV series spanning multiple season subdirectories
+it is the common prefix, e.g. `/mnt/disk4/TV Shows/Show (2001)`. This is what
+P2's rsync uses as the source. Do not refactor to "title-derived path" — the
+actual filesystem layout is the ground truth, not the Plex title string.
+
 ## Config shape
 
 `example.tiering.yaml` is the canonical source. It auto-seeds `/config/
@@ -406,18 +456,21 @@ merges over the user config via `_deep_merge()`. Keep the two in sync.
 
 ## Development rules
 
-### Read-only at runtime (until P2)
+### Write only to `/config` at runtime
 
 The container bind-mounts media read-only. `tier.py` must NOT write
 outside `/config`. If you need to spill state, put it in `/config/
-state.json` — the volume is persistent and already mounted.
+state.json` — the volume is persistent and already mounted. The one
+exception is the move executor, which writes to the hot pool destination;
+that path is a separate read-write mount.
 
-### No `--apply` without phase-gate
+### `--apply` is now live in P2.1 (TO_HOT only)
 
-`--apply` exists in the argparser and immediately exits with code 3 in
-P0/P1. Do not wire it to actual rsync calls without a corresponding phase
-bump. P2 opens this up with safety guards (currently-playing skip,
-free-space check, move-size cap, lock file).
+`--apply` executes TO_HOT moves when `moves.enabled: true`. Adding
+support for new move directions (TO_WARM, RELOCATE_WARM) requires a
+corresponding phase bump to P2.2. The full P3 safety guards (currently-
+playing skip, free-space check, move-size cap, lock file) are still
+pending — don't add them piecemeal without the full P3 spec.
 
 ### Notifiers must not raise
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,15 +498,21 @@ before waiting for CI.
 
 #### Run locally before pushing
 
+macOS system `python3` lacks pyyaml and plexapi. **Always use the venv**
+for checks 2 and 3; check 1 (compile) is fine with bare python3.
+
 ```bash
-# 1. Compile check
+# Bootstrap venv once (skip if /tmp/pmt-venv already exists)
+python3 -m venv /tmp/pmt-venv && /tmp/pmt-venv/bin/pip install pyyaml plexapi -q
+
+# 1. Compile check (bare python3 is fine — no third-party imports)
 python3 -m py_compile tier.py
 
-# 2. YAML validity
-python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
+# 2. YAML validity (needs pyyaml — use venv)
+/tmp/pmt-venv/bin/python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
 
-# 3. Inline test harness
-python3 tier.py --_test
+# 3. Inline test harness (needs pyyaml + plexapi — use venv)
+/tmp/pmt-venv/bin/python3 tier.py --_test
 ```
 
 When adding non-trivial logic (scoring tweak, new outcome, path handling),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,8 +402,14 @@ importing P3's free-space-budget complexity.
 Silent data loss is the worst possible failure mode for a file mover. rsync
 exiting 0 doesn't guarantee a complete transfer — disk-full conditions, network
 interruptions, or corruption can leave a truncated destination. The size-verify
-step (`du -sb` on source and destination, tolerance ≤ 1 KB) is the only safety
-gate between a failed rsync and a deleted source. Never bypass it to save time.
+step (`os.path.getsize` per file in `warm_disk_files`, tolerance ≤ 1 KB total)
+is the only safety gate between a failed rsync and a deleted source. Never
+bypass it to save time.
+
+Per-file measurement (not `du -sb` on the whole directory tree) is deliberate:
+it measures only the files we moved, ignoring pre-existing files already on the
+hot pool for MIXED-tier items, and is immune to concurrent downloads landing at
+the destination between rsync finishing and the verify running.
 
 **Why moves are serial, not parallel.**
 Parallel rsyncs against a parity-protected Unraid array thrash the parity disk
@@ -427,14 +433,50 @@ interrupted before the summary logged). Detecting `current_tier == HOT` on a
 TO_HOT item and logging SKIPPED instead of re-rsyncing is a cheap idempotency
 guard that prevents double-rsyncing. It does not indicate a scoring error.
 
-**`Item.source_dir` — common-ancestor directory of files on dominant disk.**
-`resolve_item_current_tier()` now returns a fourth value: the common ancestor
-directory of all resolved file paths on the dominant WARM disk. For a single
-movie file at `/mnt/disk4/Movies/Foo/foo.mkv` it is the parent directory
-`/mnt/disk4/Movies/Foo`. For a TV series spanning multiple season subdirectories
-it is the common prefix, e.g. `/mnt/disk4/TV Shows/Show (2001)`. This is what
-P2's rsync uses as the source. Do not refactor to "title-derived path" — the
-actual filesystem layout is the ground truth, not the Plex title string.
+**`Item.warm_disk_files` — the ground truth for what gets moved.**
+`resolve_item_current_tier()` returns a 5-tuple; the fifth value is
+`warm_disk_files: Dict[str, List[str]]` — a mapping of warm disk mount →
+list of resolved absolute file paths on that disk belonging to this item.
+This is what P2's rsync operates on directly via `--files-from`. Do not
+refactor to title-derived or directory-derived paths — the actual filesystem
+paths are the ground truth, not the Plex title or the common-ancestor dir.
+
+The fourth value, `source_dirs: List[str]`, is derived from `warm_disk_files`
+for display in log lines only — it is the common-ancestor directory per warm
+disk, dominant disk first. P2 does not use it for rsync.
+
+**Why rsync uses `--files-from`, not a source directory.**
+Early versions rsynced the common-ancestor directory of each item's files.
+For year-organised movie libraries (`Movies/2000/Foo.mkv`) the common ancestor
+was the year folder, causing the whole `Movies/2000/` tree to transfer instead
+of just the item's files. Switching to `--files-from` with the per-file list
+from `warm_disk_files` means only the exact files belonging to this item are
+transferred, regardless of how they are organised on disk.
+
+**Why companion files (subtitles, NFOs, etc.) are included in `warm_disk_files`.**
+`media.parts` from the Plex API only lists container files (`.mkv`, `.mp4`,
+etc.). Sidecar files (`.srt`, `.nfo`, `.sub`, language-tagged variants like
+`Movie.en.srt`) are invisible to the API but Plex discovers them at play time
+by scanning the media file's directory for files whose stem matches. If they
+are left on the warm disk after the media file moves, Plex cannot find them.
+
+`_find_companion_files(media_path)` scans the media file's parent directory
+for any file whose stem equals the media stem or starts with `stem + "."`.
+Results are appended to `warm_disk_files[disk]` so rsync picks them up.
+Do not replace this with an API-based approach — the API does not expose
+sidecar files.
+
+**Why empty ancestor directories are pruned after source delete.**
+After `os.unlink` on each source file, `_run_move_pass` walks every ancestor
+directory from the file's parent up to (but not including) the disk root and
+attempts `os.rmdir` on each, sorted deepest-first. `os.rmdir` silently fails
+on non-empty directories so the walk is safe and idempotent. Without this,
+season directories and show directories are left as empty shells on the warm
+disk after a complete series move.
+
+Each disk in `warm_disk_files` is walked against its own root, not just
+`Item.current_disk` (the dominant disk), so multi-disk series are pruned
+correctly on every contributing disk.
 
 ## Config shape
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ watch history and age, and recommends whether each item should sit on the HOT
 tier (HDD ZFS pool) or the WARM tier (Unraid parity array). Scheduled to run
 monthly or when the ZFS pool fills past a threshold.
 
-**Current status: Phase P1 (read-only).** The script connects to Plex, computes
-scores, detects the current tier of each item by probing the filesystem, and
-prints the analysis table. It still doesn't move anything — that's P2.
+**Current status: Phase P2.1 — TO_HOT moves.** The script connects to Plex,
+computes scores, detects the current tier of each item, and (when
+`moves.enabled: true`) dry-runs or executes rsync moves from the Unraid parity
+array to the hot ZFS pool. Pass `--apply` to execute; default is dry-run.
 
 ## Phase roadmap
 
@@ -20,7 +21,9 @@ prints the analysis table. It still doesn't move anything — that's P2.
 | P0.4 | Added-date floor — promote recently-added movies and TV shows with fresh episodes to HOT. | **Done** |
 | P0.5 | Disk eviction — mark warm-tier array disks as evicting; items on them get `RELOCATE_WARM`. Data model + reporting only; actual moves are P2. | **Done** |
 | P1 | Filesystem probing to detect current tier. Auto-detect array disks + Plex path translation. Majority-bytes rollup. | **Done** |
-| P2 | `--apply` with rsync moves + Plex rescan. | Pending |
+| P2.1 | Move executor — TO_HOT direction. rsync from warm array to hot pool. Dry-run by default; `--apply` executes. | **Done** |
+| P2.2 | TO_WARM + RELOCATE_WARM moves. | Pending |
+| P2.3 | Plex rescan automation post-move. | Pending |
 | P3 | Hardened safeguards (lock file, currently-playing skip, free-space check, move-size cap). | Pending |
 | P4 | Scheduled cron + size-triggered wrapper. | Pending |
 
@@ -569,6 +572,90 @@ stays `current_tier = UNKNOWN` and its outcome degrades to `SHOULD_BE_*`
 rather than `STAY_*`/`TO_*`. Look for `current_tier: UNKNOWN` in
 `--explain` output — that's the tell.
 
+## Moves (P2)
+
+The move executor (P2.1) turns `TO_HOT` recommendations into actual rsync
+operations. It is opt-in and safe by default.
+
+### Enabling
+
+```yaml
+moves:
+  enabled: true
+```
+
+With `enabled: false` (the default), the move pass is skipped entirely — the
+dry-run analysis table still prints as usual.
+
+### Dry-run vs apply
+
+**Default (no `--apply`)** — dry-run. A `[DRY-RUN]` block logs every
+projected move with source path, destination path, size, and an ETA estimate
+at 200 MB/s throughput. No filesystem changes are made.
+
+```
+[DRY-RUN] Moves: TO_HOT=3 — 12.3 GB total — estimated 1m02s at 200 MB/s
+[DRY-RUN]   Foo (2010) — 4.2 GB — /mnt/disk4/Movies/Foo (2010) → /mnt/hot_pool/Movies/Foo (2010)
+...
+```
+
+**With `--apply`** — executes moves serially. Each item is rsynced, size-verified,
+and (if configured) source-deleted. A per-item `[SUCCESS]` / `[SKIPPED]` /
+`[FAILED]` line is logged with the elapsed time.
+
+### Scope (P2.1)
+
+Only `TO_HOT` items are moved in P2.1. Items with outcome `TO_WARM`,
+`RELOCATE_WARM`, `SHOULD_BE_HOT`, or `SHOULD_BE_WARM` are tallied in a single
+skip line and left for P2.2/P2.3.
+
+### Source deletion
+
+```yaml
+moves:
+  delete_source_after_verify: true   # default
+  size_verify: true                  # default
+```
+
+The source directory is only deleted if:
+
+1. rsync exits 0, **and**
+2. `size_verify: true` and the destination byte count matches source within 1 KB.
+
+Set `delete_source_after_verify: false` for the first few apply runs to keep
+the source as a safety net. The item will exist in both locations until you
+remove the source manually.
+
+### Parity-check guard
+
+```yaml
+moves:
+  parity_check_blocking: true   # default
+```
+
+Before starting any moves, tier.py reads `/proc/mdstat` to detect whether an
+Unraid parity check or resync is running. With `parity_check_blocking: true`
+(the default), the move pass aborts before any rsync call. Set `false` for an
+escape hatch if you know what you're doing.
+
+### Bandwidth throttle
+
+```yaml
+moves:
+  bandwidth_limit_mbps: 50   # limit rsync to 50 MB/s
+```
+
+Passes `--bwlimit` to rsync. `null` (default) = unthrottled.
+
+### Recommended first-run sequence
+
+1. Set `moves.enabled: true`, leave `--apply` off. Run and check the
+   `[DRY-RUN]` block looks correct.
+2. Set `delete_source_after_verify: false`. Run with `--apply` on a small test
+   item. Confirm the destination has the file and the source still exists.
+3. After watching a few successful apply runs, set
+   `delete_source_after_verify: true`.
+
 ## Tuning
 
 All thresholds live in `tiering.yaml`. After the first few runs, look for:
@@ -590,7 +677,6 @@ recency-floor promotions appear under the `override` key in the breakdown.
 | 0 | Success |
 | 1 | Config error (file missing, token placeholder, empty libraries) |
 | 2 | Plex unreachable or auth failed |
-| 3 | `--apply` used in P0 (not yet implemented) |
 | 4 | Unhandled runtime error (notification fired if configured) |
 | 130 | Interrupted (SIGINT) |
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Community Apps template includes that mount as an "advanced" option.
 ./tier.py --quiet           # no console output, file log only
 ```
 
-`--apply` exists but errors out in P0 (read-only phase).
+`--apply` activates move execution when `moves.enabled: true`. Without it the move pass runs in dry-run mode.
 
 ## Scoring
 
@@ -603,6 +603,16 @@ at 200 MB/s throughput. No filesystem changes are made.
 and (if configured) source-deleted. A per-item `[SUCCESS]` / `[SKIPPED]` /
 `[FAILED]` line is logged with the elapsed time.
 
+**Scheduled runs (no CLI access)** — set `moves.apply: true` in `tiering.yaml`
+instead of passing `--apply` on the command line. The two flags are additive;
+either alone is sufficient to trigger apply mode.
+
+```yaml
+moves:
+  enabled: true
+  apply: true   # execute moves without --apply on the CLI
+```
+
 ### Scope (P2.1)
 
 Only `TO_HOT` items are moved in P2.1. Items with outcome `TO_WARM`,
@@ -617,14 +627,27 @@ moves:
   size_verify: true                  # default
 ```
 
-The source directory is only deleted if:
+Source files are only deleted if:
 
 1. rsync exits 0, **and**
 2. `size_verify: true` and the destination byte count matches source within 1 KB.
 
+Verification is done per-file using `os.path.getsize`, measuring only the
+files that were moved. Pre-existing files already on the hot pool (for
+partially-migrated MIXED-tier items) are not counted, avoiding false failures.
+
+After deletion, empty ancestor directories (season folders, show folders, year
+folders, etc.) are automatically pruned up to but not including the disk root.
+Non-empty directories are left untouched.
+
 Set `delete_source_after_verify: false` for the first few apply runs to keep
 the source as a safety net. The item will exist in both locations until you
 remove the source manually.
+
+Sidecar files (`.nfo`, `.srt`, `.sub`, language-tagged subtitles like
+`Movie.en.srt`) are moved alongside the media file automatically — Plex
+discovers them by directory scan at play time, so they must live on the same
+tier as the media.
 
 ### Parity-check guard
 

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -171,6 +171,38 @@ array_disk_evict:
   # - "/mnt/disk7"   # disk developing bad sectors — drain before retirement
   # - "/mnt/disk2"   # cabling issues — drain before debug
 
+# Move executor (P2.1) — controls rsync moves from WARM array to HOT pool.
+#
+# Default: enabled=false — the move pass is skipped entirely (no log lines).
+# Set enabled=true to activate dry-run reporting. Add --apply on the CLI to
+# actually execute moves. Scope: TO_HOT only in P2.1.
+#
+# Recommended first-run sequence:
+#   1. Set enabled=true, leave --apply off. Confirm the dry-run list looks sane.
+#   2. Set delete_source_after_verify=false. Run with --apply on one test item.
+#      Confirm the destination has the file and source is untouched.
+#   3. Set delete_source_after_verify=true when you trust the verify step.
+moves:
+  enabled: false
+  # rsync flags applied to every move. -aH preserves permissions, timestamps,
+  # and hardlinks. --partial keeps partial transfers so a restart doesn't start
+  # from zero. --inplace writes directly to the destination file.
+  rsync_options: ["-aH", "--partial", "--inplace"]
+  # Delete the source directory after rsync exits 0 AND size-verify passes.
+  # Set false for the first few apply runs to keep the source as a safety net.
+  delete_source_after_verify: true
+  # Verify destination byte count matches source within 1 KB before deleting.
+  # Strongly recommended — disabling skips the only safety gate before delete.
+  size_verify: true
+  # Abort the move pass if an Unraid parity check or resync is in progress.
+  # Parity recalculation is sensitive to concurrent writes; blocking is safest.
+  # Set false if you need an escape hatch and understand the risk.
+  parity_check_blocking: true
+  # Throttle rsync to this many MB/s. null = unthrottled. Useful if you want
+  # moves to run in the background without saturating the array.
+  bandwidth_limit_mbps: null
+  # - 50    # example: cap at 50 MB/s
+
 # Capacity — not used in P0, wired up in P3.
 # Budget-aware promotion/demotion keeps the hot ZFS pool under the ceiling.
 capacity:

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -184,6 +184,10 @@ array_disk_evict:
 #   3. Set delete_source_after_verify=true when you trust the verify step.
 moves:
   enabled: false
+  # Set apply: true to execute moves without passing --apply on the CLI.
+  # Useful for scheduled runs (e.g. Unraid User Scripts) where you can't
+  # append CLI flags. Equivalent to --apply; both flags are additive.
+  apply: false
   # rsync flags applied to every move. -aH preserves permissions, timestamps,
   # and hardlinks. --partial keeps partial transfers so a restart doesn't start
   # from zero. --inplace writes directly to the destination file.

--- a/tier.py
+++ b/tier.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-tier.py — Unraid media tiering script (Phase P1, read-only)
+tier.py — Unraid media tiering script (Phase P2.1)
 
 Pulls watch history and metadata from Plex, computes a heat score per
 media item (movies + TV series), probes the filesystem to determine
-where each item currently lives, and prints a table showing the
-recommended tier placement: HOT (fast pool), WARM (Unraid array), or
-STAY.
+where each item currently lives, and recommends where it should live —
+HOT (fast pool) or WARM (Unraid array). With --apply and moves.enabled,
+executes TO_HOT rsync moves serially.
 
 Phase status:
   P0  (done)        Read-only analysis from Plex catalog + watch history.
@@ -23,23 +23,27 @@ Phase status:
                     evicting; items on them get RELOCATE_WARM so P2
                     knows to move them regardless of tier score. Data
                     model + reporting only; actual moves are P2.
-  P1  (this file)   Filesystem probing to detect current tier. Auto-
+  P1  (done)        Filesystem probing to detect current tier. Auto-
                     detects array disks, translates Plex-side paths via
                     plex_path_map, rolls multi-part items up by bytes.
-  P2  (later)       Adds --apply with rsync moves + Plex rescan.
+  P2.1 (this file)  Move executor — TO_HOT direction. rsync from warm
+                    array disk to hot ZFS pool. Dry-run by default;
+                    --apply executes. Source deleted after size-verify
+                    when delete_source_after_verify=true.
+  P2.2 (later)      TO_WARM + RELOCATE_WARM moves.
+  P2.3 (later)      Plex rescan automation.
   P3  (later)       Hardened safeguards (lock file, currently-playing skip,
                     free-space check, max-move cap).
   P4  (later)       Scheduled cron + size-triggered wrapper.
 
 Usage:
     tier.py [--config PATH] [--library NAME ...] [--json|--csv PATH]
-            [--explain TITLE] [--sort COL] [--top N]
+            [--explain TITLE] [--sort COL] [--top N] [--apply]
 
 Exit codes:
     0  success
     1  configuration error
     2  Plex unreachable or auth failed
-    3  --apply used in P0 (not yet implemented)
     4  unhandled runtime error (notification fired if configured)
   130  interrupted (SIGINT)
 """
@@ -160,6 +164,16 @@ DEFAULT_CONFIG = {
     "array_disk_evict": {
         "enabled": False,
         "disks": [],  # disk paths matching paths.array_disks format
+    },
+    # Move executor (P2). Requires --apply to execute; dry-run always when off.
+    # enabled: false means the move pass is skipped entirely — no log lines.
+    "moves": {
+        "enabled": False,
+        "rsync_options": ["-aH", "--partial", "--inplace"],
+        "delete_source_after_verify": True,
+        "size_verify": True,
+        "parity_check_blocking": True,
+        "bandwidth_limit_mbps": None,
     },
     "logging": {
         "path": "/config/tier.log",  # container-friendly default
@@ -362,6 +376,7 @@ class Item:
     # --- filled in at P1+ ---
     current_tier: str = "UNKNOWN"  # 'HOT' | 'WARM' | 'UNKNOWN'
     current_disk: Optional[str] = None  # dominant warm disk path; None if HOT/UNKNOWN/MIXED
+    source_dir: Optional[str] = None    # resolved local dir containing item's files on current_disk
     # --- decision ---
     outcome: str = "NEUTRAL"       # See decide_outcome() for P0 values
     # --- collection-pin support ---
@@ -660,15 +675,16 @@ def resolve_item_current_tier(
     hot_mount: str,
     array_disks: List[str],
     user_share_prefix: str = "",
-) -> Tuple[str, dict, Optional[str]]:
+) -> Tuple[str, dict, Optional[str], Optional[str]]:
     """Majority-bytes rollup of tier for a multi-part item.
 
     parts: iterable of (plex_file_path, size_bytes).
     Returns:
-      (tier_str, breakdown, dominant_warm_disk)
+      (tier_str, breakdown, dominant_warm_disk, source_dir)
       tier_str: 'HOT' | 'WARM' | 'MIXED' | 'UNKNOWN'
       breakdown: dict of per-tier byte shares (0.0..1.0)
       dominant_warm_disk: path of the WARM disk with most bytes, or None
+      source_dir: common ancestor directory of all files on dominant disk, or None
 
     Decision rules:
       - Majority (>50%) bytes on HOT  -> HOT
@@ -678,6 +694,7 @@ def resolve_item_current_tier(
     """
     totals = {"HOT": 0, "WARM": 0, "UNKNOWN": 0}
     disk_bytes: dict = {}  # warm disk path -> bytes on that disk
+    disk_files: dict = {}  # warm disk path -> list of resolved file paths
     total = 0
     for plex_path, size in parts:
         if not size or size <= 0:
@@ -692,18 +709,27 @@ def resolve_item_current_tier(
                 d = disk.rstrip("/")
                 if resolved == d or resolved.startswith(d + "/"):
                     disk_bytes[disk] = disk_bytes.get(disk, 0) + size
+                    disk_files.setdefault(disk, []).append(resolved)
                     break
     dominant = max(disk_bytes, key=disk_bytes.__getitem__) if disk_bytes else None
+    # Compute source_dir: common ancestor of all files on the dominant disk.
+    # For a single file /disk/Movies/Foo/foo.mkv → dirname → /disk/Movies/Foo.
+    # For multi-file: os.path.commonpath gives the shared directory already.
+    source_dir: Optional[str] = None
+    if dominant and disk_files.get(dominant):
+        files = disk_files[dominant]
+        cp = os.path.commonpath(files)
+        source_dir = os.path.dirname(cp) if cp in files else cp
     if total == 0:
-        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None
+        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, None
     split = {k: round(v / total, 4) for k, v in totals.items()}
     if split["HOT"] > 0.5:
-        return "HOT", split, None
+        return "HOT", split, None, None
     if split["WARM"] > 0.5:
-        return "WARM", split, dominant
+        return "WARM", split, dominant, source_dir
     if split["UNKNOWN"] > 0.5:
-        return "UNKNOWN", split, None
-    return "MIXED", split, dominant
+        return "UNKNOWN", split, None, None
+    return "MIXED", split, dominant, source_dir
 
 
 def _media_parts(media_list) -> Iterable[Tuple[str, int]]:
@@ -1281,12 +1307,13 @@ def collect_movies(
         # Current tier (P1). Probes only if tier detection is configured.
         current_tier = "UNKNOWN"
         current_disk: Optional[str] = None
+        source_dir: Optional[str] = None
         tier_split: Optional[dict] = None
         if tier_probing:
             parts = []
             for m in group:
                 parts.extend(_media_parts(getattr(m, "media", None)))
-            current_tier, tier_split, current_disk = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dir = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1309,6 +1336,7 @@ def collect_movies(
             score=score,
             current_tier=current_tier,
             current_disk=current_disk,
+            source_dir=source_dir,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=primary_rk,
             recently_added=recently_added,
@@ -1389,12 +1417,13 @@ def collect_series(
         # Current tier (P1): majority-bytes rollup across every episode.
         current_tier = "UNKNOWN"
         current_disk: Optional[str] = None
+        source_dir: Optional[str] = None
         tier_split: Optional[dict] = None
         if tier_probing:
             parts = []
             for ep in episodes:
                 parts.extend(_media_parts(getattr(ep, "media", None)))
-            current_tier, tier_split, current_disk = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dir = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1412,6 +1441,7 @@ def collect_series(
             score=score,
             current_tier=current_tier,
             current_disk=current_disk,
+            source_dir=source_dir,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=rk,
             recently_added=recently_added,
@@ -1692,6 +1722,244 @@ def _fmt_size(gb: float) -> str:
     return f"{gb:.1f} GB"
 
 
+def _fmt_eta(seconds: float) -> str:
+    secs = int(seconds)
+    h, rem = divmod(secs, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m{s:02d}s"
+    if m:
+        return f"{m}m{s:02d}s"
+    return f"{s}s"
+
+
+# ---------- Move executor (P2) ----------
+
+# Assumed throughput for ETA estimates (spinning array → ZFS NVMe).
+_ASSUMED_THROUGHPUT_BPS = 200 * 1024 * 1024  # 200 MB/s
+
+
+def _compute_destination_path(item: "Item", hot_pool_mount: str) -> Optional[str]:
+    """Return the hot-pool path for a TO_HOT move.
+
+    Strips item.current_disk prefix from item.source_dir and prepends
+    hot_pool_mount. Returns None if source_dir or current_disk is unset
+    or inconsistent (logged by caller).
+    """
+    if not item.source_dir or not item.current_disk:
+        return None
+    disk = item.current_disk.rstrip("/")
+    if not item.source_dir.startswith(disk + "/") and item.source_dir != disk:
+        return None
+    rel = item.source_dir[len(disk):]
+    return hot_pool_mount.rstrip("/") + rel
+
+
+def _check_parity_in_progress() -> bool:
+    """Return True if an Unraid parity check or resync is running."""
+    try:
+        content = Path("/proc/mdstat").read_text()
+        return bool(re.search(r"\b(check|resync)\b", content))
+    except OSError:
+        return False
+
+
+def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
+    """Dry-run or execute the TO_HOT move pass.
+
+    When apply=False: emits [DRY-RUN] log lines for every projected move.
+    When apply=True:  executes rsync serially, verifies sizes, optionally
+                      deletes the source after successful verification.
+
+    Skips the entire pass if moves.enabled is false in config.
+    """
+    moves_cfg = cfg.get("moves") or {}
+    if not moves_cfg.get("enabled"):
+        return
+
+    hot_mount = (cfg.get("paths") or {}).get("hot_pool_mount") or ""
+    if not hot_mount:
+        log.warning("Moves: moves.enabled=true but paths.hot_pool_mount not set — skipping")
+        return
+
+    # Tally outcomes not yet supported so we can emit a single skip line.
+    skip_outcomes: dict = {}
+    for it in items:
+        if it.outcome in ("TO_WARM", "RELOCATE_WARM", "SHOULD_BE_HOT", "SHOULD_BE_WARM"):
+            skip_outcomes[it.outcome] = skip_outcomes.get(it.outcome, 0) + 1
+    if skip_outcomes:
+        parts_str = "  ".join(f"{k}={v}" for k, v in sorted(skip_outcomes.items()))
+        log.info(
+            "Moves: skipping %d items in directions not yet supported (%s)",
+            sum(skip_outcomes.values()), parts_str,
+        )
+
+    to_hot = [it for it in items if it.outcome == "TO_HOT"]
+
+    # Resolve source/destination for each candidate.
+    moves: List[tuple] = []  # (item, src, dst)
+    for it in to_hot:
+        if it.current_tier == "HOT":
+            # Already on hot pool — handled as [SKIPPED] in the loop below.
+            moves.append((it, it.source_dir, None))
+            continue
+        dst = _compute_destination_path(it, hot_mount)
+        if dst is None:
+            log.warning(
+                "Moves: [SKIP] %s — cannot compute destination "
+                "(source_dir=%r current_disk=%r)",
+                it.title_year, it.source_dir, it.current_disk,
+            )
+            continue
+        moves.append((it, it.source_dir, dst))
+
+    if not moves:
+        log.info("Moves: no actionable TO_HOT items")
+        return
+
+    total_bytes = sum(it.size_bytes for it, _, dst in moves if dst is not None)
+
+    if not apply:
+        eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
+        log.info(
+            "[DRY-RUN] Moves: TO_HOT=%d — %s total — estimated %s at 200 MB/s",
+            len([m for m in moves if m[2] is not None]),
+            _fmt_size(total_bytes / (1024 ** 3)),
+            eta,
+        )
+        for it, src, dst in moves:
+            if dst is None:
+                log.info("[DRY-RUN]   %s — already on hot pool (SKIPPED)", it.title_year)
+            else:
+                log.info(
+                    "[DRY-RUN]   %s — %s — %s → %s",
+                    it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)), src, dst,
+                )
+        return
+
+    # --apply mode.
+    parity_blocking = moves_cfg.get("parity_check_blocking", True)
+    if _check_parity_in_progress():
+        if parity_blocking:
+            log.error("Moves: parity check in progress — aborting move pass")
+            return
+        log.warning("Moves: parity check in progress — proceeding (parity_check_blocking=false)")
+
+    rsync_opts = list(moves_cfg.get("rsync_options") or ["-aH", "--partial", "--inplace"])
+    bwlimit = moves_cfg.get("bandwidth_limit_mbps")
+    if bwlimit:
+        rsync_opts.append(f"--bwlimit={int(bwlimit) * 1024}")  # rsync expects KB/s
+
+    delete_after = moves_cfg.get("delete_source_after_verify", True)
+    size_verify = moves_cfg.get("size_verify", True)
+
+    eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
+    log.info(
+        "Moves: TO_HOT=%d (apply mode) — %s total — ETA ~%s",
+        len(moves), _fmt_size(total_bytes / (1024 ** 3)), eta,
+    )
+
+    n_success = n_skipped = n_failed = 0
+    affected_libraries: set = set()
+    run_start = datetime.now(timezone.utc)
+
+    for idx, (it, src, dst) in enumerate(moves, 1):
+        prefix = f"  [{idx}/{len(moves)}]"
+        item_start = datetime.now(timezone.utc)
+
+        if dst is None or it.current_tier == "HOT":
+            log.info("%s [SKIPPED] %s — already on hot pool (no-op)", prefix, it.title_year)
+            n_skipped += 1
+            continue
+
+        # Ensure destination parent directory exists.
+        dst_parent = str(Path(dst).parent)
+        try:
+            Path(dst_parent).mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            log.error(
+                "%s [FAILED] %s — cannot create %s: %s",
+                prefix, it.title_year, dst_parent, exc,
+            )
+            n_failed += 1
+            continue
+
+        # rsync source directory into destination.
+        cmd = ["rsync"] + rsync_opts + [src.rstrip("/") + "/", dst.rstrip("/") + "/"]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except OSError as exc:
+            log.error("%s [FAILED] %s — rsync failed to start: %s", prefix, it.title_year, exc)
+            n_failed += 1
+            continue
+
+        if result.returncode != 0:
+            log.error(
+                "%s [FAILED] %s — rsync exit %d — source unchanged",
+                prefix, it.title_year, result.returncode,
+            )
+            n_failed += 1
+            continue
+
+        # Size verification.
+        if size_verify:
+            try:
+                src_du = subprocess.run(["du", "-sb", src], capture_output=True, text=True)
+                dst_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
+                src_sz = int(src_du.stdout.split()[0]) if src_du.returncode == 0 else None
+                dst_sz = int(dst_du.stdout.split()[0]) if dst_du.returncode == 0 else None
+                if src_sz is None or dst_sz is None or abs(src_sz - dst_sz) > 1024:
+                    log.error(
+                        "%s [FAILED] %s — size verify failed (src=%s dst=%s) — source unchanged",
+                        prefix, it.title_year, src_sz, dst_sz,
+                    )
+                    n_failed += 1
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                log.error(
+                    "%s [FAILED] %s — size verify error: %s — source unchanged",
+                    prefix, it.title_year, exc,
+                )
+                n_failed += 1
+                continue
+
+        # Delete source if configured.
+        if delete_after:
+            try:
+                subprocess.run(["rm", "-rf", src], check=True, capture_output=True)
+            except subprocess.CalledProcessError as exc:
+                elapsed = (datetime.now(timezone.utc) - item_start).total_seconds()
+                log.warning(
+                    "%s [SUCCESS*] %s — %s in %s — moved OK but source removal failed: %s",
+                    prefix, it.title_year,
+                    _fmt_size(it.size_bytes / (1024 ** 3)), _fmt_eta(elapsed), exc,
+                )
+                n_success += 1
+                affected_libraries.add(it.library)
+                continue
+
+        elapsed = (datetime.now(timezone.utc) - item_start).total_seconds()
+        log.info(
+            "%s [SUCCESS] %s — %s in %s — %s → %s",
+            prefix, it.title_year,
+            _fmt_size(it.size_bytes / (1024 ** 3)), _fmt_eta(elapsed),
+            it.current_disk, hot_mount,
+        )
+        n_success += 1
+        affected_libraries.add(it.library)
+
+    total_elapsed = (datetime.now(timezone.utc) - run_start).total_seconds()
+    log.info(
+        "Moves complete: %d successful, %d skipped, %d failed (%s total)",
+        n_success, n_skipped, n_failed, _fmt_eta(total_elapsed),
+    )
+    if affected_libraries:
+        log.info(
+            "Plex rescan recommended for sections: %s",
+            ", ".join(sorted(affected_libraries)),
+        )
+
+
 # Outcomes that map to each projected tier if every recommendation were
 # executed. The bucket reflects where the item will END UP, not where it
 # currently sits — so TO_HOT + STAY_HOT + PIN_HOT all go into HOT.
@@ -1904,7 +2172,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--apply", action="store_true",
-        help="(P2+) execute moves — NOT YET IMPLEMENTED, will error out",
+        help="execute moves (requires moves.enabled=true in config; default is dry-run)",
     )
     p.add_argument(
         "--log-file", type=Path, default=None,
@@ -1937,17 +2205,15 @@ def _run(args) -> int:
 
     log.info("tier.py starting — config=%s", args.config)
 
-    if args.apply:
-        log.error(
-            "--apply is not implemented in P0 (read-only). "
-            "Ship P1 (tier detection) and P2 (rsync moves) first."
-        )
-        return 3
-
     plex = connect_plex(cfg["plex"]["url"], cfg["plex"]["token"], notifier, ncfg)
 
     items = collect_all(plex, cfg, filter_libraries=args.library)
     items = apply_sort(items, args.sort)
+
+    # Move pass runs on the full scored list before --top truncation so every
+    # TO_HOT item is considered regardless of display limit.
+    _run_move_pass(items, cfg, apply=args.apply)
+
     if args.top:
         items = items[: args.top]
 
@@ -2808,7 +3074,7 @@ def _test_dominant_warm_disk_movie_with_year_folder():
         array_disks = [disk1, disk7]
         path_map    = []
 
-        tier, breakdown, dominant = resolve_item_current_tier(
+        tier, breakdown, dominant, _src_dir = resolve_item_current_tier(
             [(plex_path, 5_000_000_000)],
             path_map, hot, array_disks, user_prefix,
         )
@@ -2838,7 +3104,7 @@ def _test_dominant_warm_disk_single_file_item():
         plex_path   = "/mnt/user/Movies/" + fname
         array_disks = [disk7]
 
-        tier, breakdown, dominant = resolve_item_current_tier(
+        tier, breakdown, dominant, _src_dir = resolve_item_current_tier(
             [(plex_path, 8_000_000_000)],
             path_map=[], hot_mount=hot, array_disks=array_disks,
             user_share_prefix=user_prefix,
@@ -2869,6 +3135,208 @@ def _test_eviction_movie_on_evict_disk_becomes_relocate():
         f"expected RELOCATE_WARM for movie kind, got {item.outcome}"
     )
     print("_test_eviction_movie_on_evict_disk_becomes_relocate: OK")
+
+
+def _test_destination_path_movie_tohot():
+    """Movie item: destination = hot_pool_mount / library / title_year."""
+    item = _make_item(
+        kind="movie", library="Movies", title="Foo", year=2010,
+        current_disk="/mnt/disk4",
+        source_dir="/mnt/disk4/Movies/Foo (2010)",
+    )
+    dst = _compute_destination_path(item, "/mnt/zfs_media")
+    assert dst == "/mnt/zfs_media/Movies/Foo (2010)", f"got {dst!r}"
+    print("_test_destination_path_movie_tohot: OK")
+
+
+def _test_destination_path_series_tohot():
+    """Series item: destination = hot_pool_mount / library / title_year."""
+    item = _make_item(
+        kind="series", library="TV Shows", title="Show", year=2001,
+        current_disk="/mnt/disk2",
+        source_dir="/mnt/disk2/TV Shows/Show (2001)",
+    )
+    dst = _compute_destination_path(item, "/mnt/zfs_media")
+    assert dst == "/mnt/zfs_media/TV Shows/Show (2001)", f"got {dst!r}"
+    print("_test_destination_path_series_tohot: OK")
+
+
+def _test_move_skipped_when_already_hot():
+    """TO_HOT item whose current_tier is already HOT -> SKIPPED, no rsync."""
+    calls = []
+
+    def _fake_run(cmd, **_kw):
+        calls.append(cmd)
+        class R:
+            returncode = 0
+            stdout = "0\t/path"
+        return R()
+
+    item = _make_item(
+        kind="movie", library="Movies",
+        current_tier="HOT", current_disk="/mnt/disk4",
+        source_dir="/mnt/disk4/Movies/Foo (2010)",
+    )
+    item.outcome = "TO_HOT"
+
+    cfg = {
+        "moves": {
+            "enabled": True, "rsync_options": ["-aH"],
+            "delete_source_after_verify": False, "size_verify": False,
+            "parity_check_blocking": False, "bandwidth_limit_mbps": None,
+        },
+        "paths": {"hot_pool_mount": "/mnt/zfs_media"},
+    }
+
+    orig = subprocess.run
+    try:
+        subprocess.run = _fake_run
+        _run_move_pass([item], cfg, apply=True)
+    finally:
+        subprocess.run = orig
+
+    rsync_calls = [c for c in calls if c and c[0] == "rsync"]
+    assert not rsync_calls, f"rsync must not be called for already-HOT item, got {rsync_calls}"
+    print("_test_move_skipped_when_already_hot: OK")
+
+
+def _test_dry_run_emits_no_apply_call():
+    """Dry-run path never invokes rsync subprocess."""
+    calls = []
+
+    def _fake_run(cmd, **_kw):
+        calls.append(cmd)
+        class R:
+            returncode = 0
+            stdout = ""
+        return R()
+
+    item = _make_item(
+        kind="movie", library="Movies",
+        current_tier="WARM", current_disk="/mnt/disk4",
+        source_dir="/mnt/disk4/Movies/Foo (2010)",
+    )
+    item.outcome = "TO_HOT"
+
+    cfg = {
+        "moves": {
+            "enabled": True, "rsync_options": ["-aH"],
+            "delete_source_after_verify": True, "size_verify": True,
+            "parity_check_blocking": True, "bandwidth_limit_mbps": None,
+        },
+        "paths": {"hot_pool_mount": "/mnt/zfs_media"},
+    }
+
+    orig = subprocess.run
+    try:
+        subprocess.run = _fake_run
+        _run_move_pass([item], cfg, apply=False)
+    finally:
+        subprocess.run = orig
+
+    assert not calls, f"dry-run must make zero subprocess calls, got {calls}"
+    print("_test_dry_run_emits_no_apply_call: OK")
+
+
+def _test_parity_check_aborts_pass():
+    """/proc/mdstat showing a check causes the move pass to abort before rsync."""
+    import unittest.mock as _mock
+
+    rsync_calls = []
+
+    def _fake_run(cmd, **_kw):
+        if cmd and cmd[0] == "rsync":
+            rsync_calls.append(cmd)
+        class R:
+            returncode = 0
+            stdout = "0\t/path"
+        return R()
+
+    item = _make_item(
+        kind="movie", library="Movies",
+        current_tier="WARM", current_disk="/mnt/disk4",
+        source_dir="/mnt/disk4/Movies/Foo (2010)",
+    )
+    item.outcome = "TO_HOT"
+
+    cfg = {
+        "moves": {
+            "enabled": True, "rsync_options": ["-aH"],
+            "delete_source_after_verify": False, "size_verify": False,
+            "parity_check_blocking": True, "bandwidth_limit_mbps": None,
+        },
+        "paths": {"hot_pool_mount": "/mnt/zfs_media"},
+    }
+
+    mdstat_content = (
+        "Personalities : [raid6] [raid5]\n"
+        "md0 : active raid5 sdg1[6] sdf1[5]\n"
+        "      check=22.3% (123456/554432) finish=14.2min speed=123K/sec\n"
+    )
+
+    orig_run = subprocess.run
+    try:
+        subprocess.run = _fake_run
+        with _mock.patch.object(Path, "read_text", return_value=mdstat_content):
+            _run_move_pass([item], cfg, apply=True)
+    finally:
+        subprocess.run = orig_run
+
+    assert not rsync_calls, f"rsync must not run when parity check active, got {rsync_calls}"
+    print("_test_parity_check_aborts_pass: OK")
+
+
+def _test_size_verify_failure_skips_delete():
+    """Size mismatch after rsync -> item marked FAILED, rm -rf NOT called."""
+    rm_calls = []
+
+    def _fake_run(cmd, **_kw):
+        class R:
+            stdout = ""
+            returncode = 0
+        r = R()
+        if cmd and cmd[0] == "rsync":
+            r.returncode = 0
+        elif cmd and cmd[0] == "du":
+            # Return mismatched sizes: src=100, dst=5000000 (diff >> 1024 tolerance)
+            path = cmd[-1]
+            r.stdout = f"{'100' if 'disk4' in path else '5000000'}\t{path}\n"
+        elif cmd and cmd[0] == "rm":
+            rm_calls.append(cmd)
+        return r
+
+    import tempfile, os as _os
+    with tempfile.TemporaryDirectory() as root:
+        src = _os.path.join(root, "disk4", "Movies", "Foo (2010)")
+        dst_parent = _os.path.join(root, "zfs_media", "Movies")
+        _os.makedirs(src, exist_ok=True)
+        _os.makedirs(dst_parent, exist_ok=True)
+
+        item = _make_item(
+            kind="movie", library="Movies",
+            current_tier="WARM", current_disk=_os.path.join(root, "disk4"),
+            source_dir=src,
+        )
+        item.outcome = "TO_HOT"
+
+        cfg = {
+            "moves": {
+                "enabled": True, "rsync_options": ["-aH"],
+                "delete_source_after_verify": True, "size_verify": True,
+                "parity_check_blocking": False, "bandwidth_limit_mbps": None,
+            },
+            "paths": {"hot_pool_mount": _os.path.join(root, "zfs_media")},
+        }
+
+        orig = subprocess.run
+        try:
+            subprocess.run = _fake_run
+            _run_move_pass([item], cfg, apply=True)
+        finally:
+            subprocess.run = orig
+
+    assert not rm_calls, f"rm -rf must NOT be called on size mismatch, got {rm_calls}"
+    print("_test_size_verify_failure_skips_delete: OK")
 
 
 if __name__ == "__main__":
@@ -2903,5 +3371,11 @@ if __name__ == "__main__":
         _test_dominant_warm_disk_movie_with_year_folder()
         _test_dominant_warm_disk_single_file_item()
         _test_eviction_movie_on_evict_disk_becomes_relocate()
+        _test_destination_path_movie_tohot()
+        _test_destination_path_series_tohot()
+        _test_move_skipped_when_already_hot()
+        _test_dry_run_emits_no_apply_call()
+        _test_parity_check_aborts_pass()
+        _test_size_verify_failure_skips_delete()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -67,7 +67,7 @@ import urllib.request
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 try:
     import yaml
@@ -377,9 +377,13 @@ class Item:
     # --- filled in at P1+ ---
     current_tier: str = "UNKNOWN"  # 'HOT' | 'WARM' | 'UNKNOWN'
     current_disk: Optional[str] = None  # dominant warm disk path; None if HOT/UNKNOWN/MIXED
-    # All warm disk source dirs for this item (dominant disk first). A series
-    # split across multiple array disks will have one entry per disk so the
-    # move executor can rsync every disk's content to the hot pool in one pass.
+    # Actual warm-disk file paths for this item, keyed by disk mount path.
+    # Used by the move executor: rsync transfers exactly these files regardless
+    # of how the library is organised on disk (per-item folders vs shared
+    # year folders). Dominant disk is at key == current_disk.
+    warm_disk_files: Dict[str, List[str]] = field(default_factory=dict)
+    # Common-ancestor source dirs (dominant disk first) — kept for display /
+    # log output only.  NOT used for rsync source paths.
     source_dirs: List[str] = field(default_factory=list)
     # --- decision ---
     outcome: str = "NEUTRAL"       # See decide_outcome() for P0 values
@@ -679,16 +683,17 @@ def resolve_item_current_tier(
     hot_mount: str,
     array_disks: List[str],
     user_share_prefix: str = "",
-) -> Tuple[str, dict, Optional[str], List[str]]:
+) -> Tuple[str, dict, Optional[str], List[str], Dict[str, List[str]]]:
     """Majority-bytes rollup of tier for a multi-part item.
 
     parts: iterable of (plex_file_path, size_bytes).
     Returns:
-      (tier_str, breakdown, dominant_warm_disk, source_dir)
+      (tier_str, breakdown, dominant_warm_disk, source_dirs, warm_disk_files)
       tier_str: 'HOT' | 'WARM' | 'MIXED' | 'UNKNOWN'
       breakdown: dict of per-tier byte shares (0.0..1.0)
       dominant_warm_disk: path of the WARM disk with most bytes, or None
-      source_dir: common ancestor directory of all files on dominant disk, or None
+      source_dirs: common-ancestor dirs per warm disk (dominant first) — display only
+      warm_disk_files: {disk: [resolved file paths]} for all warm disks
 
     Decision rules:
       - Majority (>50%) bytes on HOT  -> HOT
@@ -698,7 +703,7 @@ def resolve_item_current_tier(
     """
     totals = {"HOT": 0, "WARM": 0, "UNKNOWN": 0}
     disk_bytes: dict = {}  # warm disk path -> bytes on that disk
-    disk_files: dict = {}  # warm disk path -> list of resolved file paths
+    disk_files: Dict[str, List[str]] = {}  # warm disk path -> list of resolved file paths
     total = 0
     for plex_path, size in parts:
         if not size or size <= 0:
@@ -716,11 +721,7 @@ def resolve_item_current_tier(
                     disk_files.setdefault(disk, []).append(resolved)
                     break
     dominant = max(disk_bytes, key=disk_bytes.__getitem__) if disk_bytes else None
-    # Build source dirs for every warm disk (dominant first). A series split
-    # across multiple array disks gets one entry per disk so the move executor
-    # can rsync all of them to the hot pool in one pass.
-    # For a single file /disk/Lib/Title/foo.mkv → dirname → /disk/Lib/Title.
-    # For multi-file commonpath already returns the shared directory.
+    # Build display-only source dirs (common ancestor per disk, dominant first).
     warm_source_dirs: List[str] = []
     for disk, files in disk_files.items():
         if not files:
@@ -732,15 +733,15 @@ def resolve_item_current_tier(
         else:
             warm_source_dirs.append(src)
     if total == 0:
-        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, []
+        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, [], {}
     split = {k: round(v / total, 4) for k, v in totals.items()}
     if split["HOT"] > 0.5:
-        return "HOT", split, None, []
+        return "HOT", split, None, [], {}
     if split["WARM"] > 0.5:
-        return "WARM", split, dominant, warm_source_dirs
+        return "WARM", split, dominant, warm_source_dirs, dict(disk_files)
     if split["UNKNOWN"] > 0.5:
-        return "UNKNOWN", split, None, []
-    return "MIXED", split, dominant, warm_source_dirs
+        return "UNKNOWN", split, None, [], {}
+    return "MIXED", split, dominant, warm_source_dirs, dict(disk_files)
 
 
 def _media_parts(media_list) -> Iterable[Tuple[str, int]]:
@@ -1324,7 +1325,7 @@ def collect_movies(
             parts = []
             for m in group:
                 parts.extend(_media_parts(getattr(m, "media", None)))
-            current_tier, tier_split, current_disk, source_dirs = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs, warm_disk_files = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1348,6 +1349,7 @@ def collect_movies(
             current_tier=current_tier,
             current_disk=current_disk,
             source_dirs=source_dirs,
+            warm_disk_files=warm_disk_files,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=primary_rk,
             recently_added=recently_added,
@@ -1434,7 +1436,7 @@ def collect_series(
             parts = []
             for ep in episodes:
                 parts.extend(_media_parts(getattr(ep, "media", None)))
-            current_tier, tier_split, current_disk, source_dirs = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs, warm_disk_files = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1453,6 +1455,7 @@ def collect_series(
             current_tier=current_tier,
             current_disk=current_disk,
             source_dirs=source_dirs,
+            warm_disk_files=warm_disk_files,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=rk,
             recently_added=recently_added,
@@ -1821,48 +1824,46 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             sum(skip_outcomes.values()), parts_str,
         )
 
-    to_hot = [it for it in items if it.outcome == "TO_HOT"]
+    # Separate already-HOT items (idempotency) from actionable TO_HOT items.
+    to_hot_skip = [it for it in items if it.outcome == "TO_HOT" and it.current_tier == "HOT"]
+    to_hot_move = [it for it in items if it.outcome == "TO_HOT" and it.current_tier != "HOT"]
 
-    # Resolve destination for each candidate. Items already on HOT are kept
-    # in the list so the per-item loop can emit [SKIPPED] with their index.
-    moves: List[tuple] = []  # (item, dst_or_None)
-    for it in to_hot:
-        if it.current_tier == "HOT":
-            moves.append((it, None))
-            continue
-        dst = _compute_destination_path(it, hot_mount)
-        if dst is None:
+    # Validate each candidate has file-level data we need for rsync.
+    moves: List["Item"] = []
+    for it in to_hot_move:
+        if not it.warm_disk_files:
             log.warning(
-                "Moves: [SKIP] %s — cannot compute destination "
-                "(source_dirs=%r current_disk=%r)",
-                it.title_year, it.source_dirs, it.current_disk,
+                "Moves: [SKIP] %s — no warm_disk_files (tier detection inactive?)",
+                it.title_year,
             )
             continue
-        moves.append((it, dst))
+        moves.append(it)
 
-    if not moves:
+    all_to_hot = len(to_hot_skip) + len(moves)
+    if not all_to_hot:
         log.info("Moves: no actionable TO_HOT items")
         return
 
-    total_bytes = sum(it.size_bytes for it, dst in moves if dst is not None)
+    total_bytes = sum(it.size_bytes for it in moves)
 
     if not apply:
         eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
         log.info(
-            "[DRY-RUN] Moves: TO_HOT=%d — %s total — estimated %s at 200 MB/s",
-            len([m for m in moves if m[1] is not None]),
+            "[DRY-RUN] Moves: TO_HOT=%d (%d skipped already-HOT) — %s total — estimated %s at 200 MB/s",
+            len(moves), len(to_hot_skip),
             _fmt_size(total_bytes / (1024 ** 3)),
             eta,
         )
-        for it, dst in moves:
-            if dst is None:
-                log.info("[DRY-RUN]   %s — already on hot pool (SKIPPED)", it.title_year)
-            else:
-                for src in it.source_dirs:
-                    log.info(
-                        "[DRY-RUN]   %s — %s — %s → %s",
-                        it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)), src, dst,
-                    )
+        for it in to_hot_skip:
+            log.info("[DRY-RUN]   %s — already on hot pool (SKIPPED)", it.title_year)
+        for it in moves:
+            n_files = sum(len(f) for f in it.warm_disk_files.values())
+            for disk, files in it.warm_disk_files.items():
+                log.info(
+                    "[DRY-RUN]   %s — %s — %d file(s) from %s → %s",
+                    it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
+                    n_files, disk, hot_mount,
+                )
         return
 
     # --apply mode.
@@ -1886,62 +1887,68 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         "Moves: TO_HOT=%d (apply mode) — %s total — ETA ~%s",
         len(moves), _fmt_size(total_bytes / (1024 ** 3)), eta,
     )
+    for it in to_hot_skip:
+        log.info("  [SKIPPED] %s — already on hot pool (no-op)", it.title_year)
 
     n_success = n_skipped = n_failed = 0
+    n_skipped = len(to_hot_skip)
     affected_libraries: set = set()
     run_start = datetime.now(timezone.utc)
 
-    for idx, (it, dst) in enumerate(moves, 1):
+    for idx, it in enumerate(moves, 1):
         prefix = f"  [{idx}/{len(moves)}]"
         item_start = datetime.now(timezone.utc)
         size_str = _fmt_size(it.size_bytes / (1024 ** 3))
-
-        if dst is None or it.current_tier == "HOT":
-            log.info("%s [SKIPPED] %s — already on hot pool (no-op)", prefix, it.title_year)
-            n_skipped += 1
-            continue
+        n_files = sum(len(f) for f in it.warm_disk_files.values())
 
         # Log before starting — long rsyncs are otherwise silent.
-        log.info("%s Moving %s — %s", prefix, it.title_year, size_str)
-        for src in it.source_dirs:
-            log.info("%s   %s → %s", prefix, src, dst)
+        log.info("%s Moving %s — %s, %d file(s)", prefix, it.title_year, size_str, n_files)
+        for disk, files in it.warm_disk_files.items():
+            log.info("%s   %s (%d files) → %s", prefix, disk, len(files), hot_mount)
 
-        # Ensure destination parent directory exists.
-        dst_parent = str(Path(dst).parent)
-        try:
-            Path(dst_parent).mkdir(parents=True, exist_ok=True)
-        except OSError as exc:
-            log.error("%s [FAILED] %s — cannot create %s: %s", prefix, it.title_year, dst_parent, exc)
-            n_failed += 1
-            continue
-
-        # Snapshot destination size before rsync. Items that were MIXED-tier may
-        # already have some files on the hot pool; we compare the delta (bytes
-        # added) against the source size, not the absolute destination total.
-        dst_before_sz = 0
-        if size_verify and Path(dst).exists():
-            try:
-                pre_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
-                dst_before_sz = int(pre_du.stdout.split()[0]) if pre_du.returncode == 0 else 0
-            except Exception:  # noqa: BLE001
-                dst_before_sz = 0
-
-        # rsync each source directory (one per warm disk) into the destination.
+        # rsync each warm disk using --files-from so only this item's files are
+        # transferred, regardless of whether the library uses per-item folders or
+        # shared year folders. Source root is the disk mount; destination root is
+        # the hot pool mount — rsync preserves the full relative path structure.
+        import tempfile as _tempfile
         rsync_failed = False
-        for src in it.source_dirs:
-            cmd = ["rsync"] + rsync_opts + [src.rstrip("/") + "/", dst.rstrip("/") + "/"]
+        for disk, files in it.warm_disk_files.items():
+            disk_root = disk.rstrip("/") + "/"
+            # Build relative paths (strip leading disk root + separator).
+            rel_paths = [f[len(disk_root):] if f.startswith(disk_root) else f.lstrip("/")
+                         for f in files]
             try:
+                with _tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".txt", delete=False, prefix="tier_rsync_"
+                ) as flist:
+                    flist.write("\n".join(rel_paths))
+                    flist_path = flist.name
+            except OSError as exc:
+                log.error("%s [FAILED] %s — cannot write files-from list: %s",
+                          prefix, it.title_year, exc)
+                rsync_failed = True
+                break
+            try:
+                cmd = (["rsync"] + rsync_opts
+                       + [f"--files-from={flist_path}", disk_root, hot_mount.rstrip("/") + "/"])
                 result = subprocess.run(cmd, capture_output=True, text=True)
             except OSError as exc:
-                log.error("%s [FAILED] %s — rsync failed to start: %s", prefix, it.title_year, exc)
+                log.error("%s [FAILED] %s — rsync failed to start: %s",
+                          prefix, it.title_year, exc)
                 rsync_failed = True
+            finally:
+                try:
+                    os.unlink(flist_path)
+                except OSError:
+                    pass
+            if rsync_failed:
                 break
             if result.returncode != 0:
                 stderr_lines = (result.stderr or "").strip().splitlines()[:5]
                 stderr_str = "; ".join(stderr_lines) if stderr_lines else ""
                 log.error(
-                    "%s [FAILED] %s — rsync exit %d (%s)%s — source unchanged",
-                    prefix, it.title_year, result.returncode, src,
+                    "%s [FAILED] %s — rsync exit %d (disk=%s)%s — source unchanged",
+                    prefix, it.title_year, result.returncode, disk,
                     f": {stderr_str}" if stderr_str else "",
                 )
                 rsync_failed = True
@@ -1950,26 +1957,25 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             n_failed += 1
             continue
 
-        # Size verification: compare bytes transferred (dst delta) against source.
-        # Using the delta rather than absolute dst size handles items that were
-        # MIXED-tier (some files already on hot pool before this run).
+        # Size verification: compare source file sizes against destination file
+        # sizes using os.path.getsize per file. File-level measurement is immune
+        # to concurrent downloads into the same directory (only the specific
+        # transferred files are measured, not the whole directory total).
         if size_verify:
             try:
-                src_sz = 0
-                for src in it.source_dirs:
-                    du = subprocess.run(["du", "-sb", src], capture_output=True, text=True)
-                    if du.returncode != 0:
-                        raise OSError(f"du failed for {src}")
-                    src_sz += int(du.stdout.split()[0])
-                dst_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
-                dst_after_sz = int(dst_du.stdout.split()[0]) if dst_du.returncode == 0 else None
-                transferred = (dst_after_sz - dst_before_sz) if dst_after_sz is not None else None
-                if transferred is None or abs(transferred - src_sz) > 1024:
+                src_sz = dst_sz = 0
+                hot = hot_mount.rstrip("/")
+                for disk, files in it.warm_disk_files.items():
+                    disk_root = disk.rstrip("/")
+                    for f in files:
+                        src_sz += os.path.getsize(f)
+                        dst_f = hot + f[len(disk_root):]
+                        if os.path.exists(dst_f):
+                            dst_sz += os.path.getsize(dst_f)
+                if abs(src_sz - dst_sz) > 1024:
                     log.error(
-                        "%s [FAILED] %s — size verify failed "
-                        "(src=%s dst_delta=%s dst_before=%s dst_after=%s) — source unchanged",
-                        prefix, it.title_year, src_sz, transferred,
-                        dst_before_sz, dst_after_sz,
+                        "%s [FAILED] %s — size verify failed (src=%s dst=%s) — source unchanged",
+                        prefix, it.title_year, src_sz, dst_sz,
                     )
                     n_failed += 1
                     continue
@@ -1981,18 +1987,32 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
                 n_failed += 1
                 continue
 
-        # Delete all source directories if configured.
+        # Delete source files individually, then prune empty parent directories.
+        # File-level delete means only this item's files are removed — other
+        # items sharing the same parent directory (e.g. a year folder) are safe.
         if delete_after:
             delete_failed = False
-            for src in it.source_dirs:
+            dirs_to_prune: set = set()
+            for disk, files in it.warm_disk_files.items():
+                for f in files:
+                    try:
+                        os.unlink(f)
+                        dirs_to_prune.add(os.path.dirname(f))
+                    except OSError as exc:
+                        log.warning(
+                            "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
+                            prefix, it.title_year, f, exc,
+                        )
+                        delete_failed = True
+            # Prune empty ancestor directories up to (but not including) disk root.
+            for d in sorted(dirs_to_prune, reverse=True):
+                disk_root = (it.current_disk or "").rstrip("/")
+                if d == disk_root or not d.startswith(disk_root):
+                    continue
                 try:
-                    subprocess.run(["rm", "-rf", src], check=True, capture_output=True)
-                except subprocess.CalledProcessError as exc:
-                    log.warning(
-                        "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
-                        prefix, it.title_year, src, exc,
-                    )
-                    delete_failed = True
+                    os.rmdir(d)  # no-op if directory still has files
+                except OSError:
+                    pass
             if delete_failed:
                 n_success += 1
                 affected_libraries.add(it.library)
@@ -3134,7 +3154,7 @@ def _test_dominant_warm_disk_movie_with_year_folder():
         array_disks = [disk1, disk7]
         path_map    = []
 
-        tier, breakdown, dominant, _src_dir = resolve_item_current_tier(
+        tier, breakdown, dominant, *_ = resolve_item_current_tier(
             [(plex_path, 5_000_000_000)],
             path_map, hot, array_disks, user_prefix,
         )
@@ -3164,7 +3184,7 @@ def _test_dominant_warm_disk_single_file_item():
         plex_path   = "/mnt/user/Movies/" + fname
         array_disks = [disk7]
 
-        tier, breakdown, dominant, _src_dir = resolve_item_current_tier(
+        tier, breakdown, dominant, *_ = resolve_item_current_tier(
             [(plex_path, 8_000_000_000)],
             path_map=[], hot_mount=hot, array_disks=array_disks,
             user_share_prefix=user_prefix,
@@ -3198,7 +3218,7 @@ def _test_eviction_movie_on_evict_disk_becomes_relocate():
 
 
 def _test_destination_path_movie_tohot():
-    """Movie item: destination = hot_pool_mount / library / title_year."""
+    """_compute_destination_path: movie with per-item folder -> correct hot path."""
     item = _make_item(
         kind="movie", library="Movies", title="Foo", year=2010,
         current_disk="/mnt/disk4",
@@ -3210,7 +3230,7 @@ def _test_destination_path_movie_tohot():
 
 
 def _test_destination_path_series_tohot():
-    """Series item: destination = hot_pool_mount / library / title_year."""
+    """_compute_destination_path: series -> correct hot path."""
     item = _make_item(
         kind="series", library="TV Shows", title="Show", year=2001,
         current_disk="/mnt/disk2",
@@ -3225,17 +3245,17 @@ def _test_move_skipped_when_already_hot():
     """TO_HOT item whose current_tier is already HOT -> SKIPPED, no rsync."""
     calls = []
 
-    def _fake_run(cmd, **_kw):
+    def _fake_run(cmd, **_):
         calls.append(cmd)
         class R:
             returncode = 0
-            stdout = "0\t/path"
+            stderr = ""
         return R()
 
     item = _make_item(
         kind="movie", library="Movies",
-        current_tier="HOT", current_disk="/mnt/disk4",
-        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
+        current_tier="HOT", current_disk=None,
+        warm_disk_files={},  # HOT items have no warm files
     )
     item.outcome = "TO_HOT"
 
@@ -3264,17 +3284,17 @@ def _test_dry_run_emits_no_apply_call():
     """Dry-run path never invokes rsync subprocess."""
     calls = []
 
-    def _fake_run(cmd, **_kw):
+    def _fake_run(cmd, **_):
         calls.append(cmd)
         class R:
             returncode = 0
-            stdout = ""
+            stderr = ""
         return R()
 
     item = _make_item(
         kind="movie", library="Movies",
         current_tier="WARM", current_disk="/mnt/disk4",
-        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
+        warm_disk_files={"/mnt/disk4": ["/mnt/disk4/Movies/2010/Foo (2010).mkv"]},
     )
     item.outcome = "TO_HOT"
 
@@ -3304,18 +3324,18 @@ def _test_parity_check_aborts_pass():
 
     rsync_calls = []
 
-    def _fake_run(cmd, **_kw):
+    def _fake_run(cmd, **_):
         if cmd and cmd[0] == "rsync":
             rsync_calls.append(cmd)
         class R:
             returncode = 0
-            stdout = "0\t/path"
+            stderr = ""
         return R()
 
     item = _make_item(
         kind="movie", library="Movies",
         current_tier="WARM", current_disk="/mnt/disk4",
-        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
+        warm_disk_files={"/mnt/disk4": ["/mnt/disk4/Movies/2010/Foo (2010).mkv"]},
     )
     item.outcome = "TO_HOT"
 
@@ -3390,35 +3410,36 @@ def _test_parity_check_unraid_active_detected():
 
 
 def _test_size_verify_failure_skips_delete():
-    """Size mismatch after rsync -> item marked FAILED, rm -rf NOT called."""
-    rm_calls = []
+    """Size mismatch after rsync -> source file must NOT be deleted.
 
-    def _fake_run(cmd, **_kw):
-        class R:
-            stdout = ""
-            returncode = 0
-        r = R()
-        if cmd and cmd[0] == "rsync":
-            r.returncode = 0
-        elif cmd and cmd[0] == "du":
-            # Return mismatched sizes: src=100, dst=5000000 (diff >> 1024 tolerance)
-            path = cmd[-1]
-            r.stdout = f"{'100' if 'disk4' in path else '5000000'}\t{path}\n"
-        elif cmd and cmd[0] == "rm":
-            rm_calls.append(cmd)
-        return r
-
+    Creates real src and dst files with different sizes. Fake rsync is a no-op
+    (doesn't update dst), so os.path.getsize sees the mismatch and skips delete.
+    """
     import tempfile, os as _os
+
     with tempfile.TemporaryDirectory() as root:
-        src = _os.path.join(root, "disk4", "Movies", "Foo (2010)")
-        dst_parent = _os.path.join(root, "zfs_media", "Movies")
-        _os.makedirs(src, exist_ok=True)
-        _os.makedirs(dst_parent, exist_ok=True)
+        disk = _os.path.join(root, "disk4")
+        hot_mount = _os.path.join(root, "zfs_media")
+        src_file = _os.path.join(disk, "Movies", "2010", "Foo (2010).mkv")
+        dst_file = _os.path.join(hot_mount, "Movies", "2010", "Foo (2010).mkv")
+        _os.makedirs(_os.path.dirname(src_file), exist_ok=True)
+        _os.makedirs(_os.path.dirname(dst_file), exist_ok=True)
+
+        with open(src_file, "wb") as f:
+            f.write(b"x" * 1000)        # src = 1 000 bytes
+        with open(dst_file, "wb") as f:
+            f.write(b"y" * 5_000_000)   # dst = 5 MB — deliberate mismatch
+
+        def _fake_run(*_a, **_kw):
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()  # rsync succeeds but doesn't touch files
 
         item = _make_item(
             kind="movie", library="Movies",
-            current_tier="WARM", current_disk=_os.path.join(root, "disk4"),
-            source_dirs=[src],
+            current_tier="WARM", current_disk=disk,
+            warm_disk_files={disk: [src_file]},
         )
         item.outcome = "TO_HOT"
 
@@ -3428,7 +3449,7 @@ def _test_size_verify_failure_skips_delete():
                 "delete_source_after_verify": True, "size_verify": True,
                 "parity_check_blocking": False, "bandwidth_limit_mbps": None,
             },
-            "paths": {"hot_pool_mount": _os.path.join(root, "zfs_media")},
+            "paths": {"hot_pool_mount": hot_mount},
         }
 
         orig = subprocess.run
@@ -3438,36 +3459,40 @@ def _test_size_verify_failure_skips_delete():
         finally:
             subprocess.run = orig
 
-    assert not rm_calls, f"rm -rf must NOT be called on size mismatch, got {rm_calls}"
+        assert _os.path.exists(src_file), "source file must NOT be deleted on size mismatch"
     print("_test_size_verify_failure_skips_delete: OK")
 
 
 def _test_multidisk_series_all_source_dirs_rsynced():
-    """Series split across two warm disks: rsync is called once per source dir."""
+    """Series split across two warm disks: rsync --files-from called once per disk."""
     import tempfile, os as _os
 
-    rsync_srcs = []
+    rsync_disk_roots = []
 
     def _fake_run(cmd, **_):
         class R:
             returncode = 0
-            stdout = "1000000\t/path"
+            stderr = ""
         if cmd and cmd[0] == "rsync":
-            rsync_srcs.append(cmd[-2])
+            # cmd = ["rsync", ...opts..., "--files-from=path", disk_root/, hot_mount/]
+            rsync_disk_roots.append(cmd[-2])
         return R()
 
     with tempfile.TemporaryDirectory() as root:
-        disk6_src = _os.path.join(root, "disk6", "TV Shows", "Reba (2001)")
-        disk3_src = _os.path.join(root, "disk3", "TV Shows", "Reba (2001)")
+        disk6 = _os.path.join(root, "disk6")
+        disk3 = _os.path.join(root, "disk3")
         hot_mount = _os.path.join(root, "zfs_media")
-        _os.makedirs(disk6_src, exist_ok=True)
-        _os.makedirs(disk3_src, exist_ok=True)
+        disk6_file = _os.path.join(disk6, "TV Shows", "Reba (2001)", "S01E01.mkv")
+        disk3_file = _os.path.join(disk3, "TV Shows", "Reba (2001)", "S03E01.mkv")
+        for f in (disk6_file, disk3_file):
+            _os.makedirs(_os.path.dirname(f), exist_ok=True)
+            open(f, "w").close()
         _os.makedirs(hot_mount, exist_ok=True)
 
         item = _make_item(
             kind="series", library="TV Shows", title="Reba", year=2001,
-            current_tier="WARM", current_disk=_os.path.join(root, "disk6"),
-            source_dirs=[disk6_src, disk3_src],
+            current_tier="WARM", current_disk=disk6,
+            warm_disk_files={disk6: [disk6_file], disk3: [disk3_file]},
         )
         item.outcome = "TO_HOT"
 
@@ -3487,60 +3512,49 @@ def _test_multidisk_series_all_source_dirs_rsynced():
         finally:
             subprocess.run = orig
 
-    assert len(rsync_srcs) == 2, f"expected 2 rsync calls, got {len(rsync_srcs)}: {rsync_srcs}"
-    assert any("disk6" in s for s in rsync_srcs), "disk6 source missing from rsync calls"
-    assert any("disk3" in s for s in rsync_srcs), "disk3 source missing from rsync calls"
+    assert len(rsync_disk_roots) == 2, (
+        f"expected 2 rsync calls (one per disk), got {len(rsync_disk_roots)}: {rsync_disk_roots}"
+    )
+    assert any("disk6" in s for s in rsync_disk_roots), "disk6 root missing from rsync calls"
+    assert any("disk3" in s for s in rsync_disk_roots), "disk3 root missing from rsync calls"
     print("_test_multidisk_series_all_source_dirs_rsynced: OK")
 
 
 def _test_size_verify_mixed_tier_preexisting_dst_passes():
-    """MIXED-tier item: destination already has pre-existing files before rsync.
+    """MIXED-tier: pre-existing file at dst does NOT count toward size verify.
 
-    Old logic compared src_sz vs dst_total and always failed (dst > src).
-    New logic compares src_sz vs (dst_after - dst_before) so pre-existing
-    content doesn't count as a mismatch.
-
-    Fake du returns: src=500B, dst_before=1000B (pre-existing), dst_after=1500B.
-    delta = 1500-1000 = 500 == src → verify passes → rm is called.
+    File-level verify measures only the specific files in warm_disk_files.
+    A pre-existing S01E01.mkv already on the hot pool is ignored; only
+    S02E01.mkv (the warm file being moved) is compared src vs dst.
     """
-    rm_calls = []
-    # Track dst du calls so we can return different values before/after rsync.
-    dst_du_calls = [0]
-
-    def _fake_run(cmd, **_):
-        class R:
-            returncode = 0
-            stderr = ""
-            stdout = ""
-        r = R()
-        if cmd and cmd[0] == "rsync":
-            pass  # success, no-op
-        elif cmd and cmd[0] == "du":
-            path = cmd[-1]
-            if "disk5" in path:
-                r.stdout = f"500\t{path}\n"       # source bytes
-            else:
-                dst_du_calls[0] += 1
-                if dst_du_calls[0] == 1:
-                    r.stdout = f"1000\t{path}\n"  # dst_before: pre-existing
-                else:
-                    r.stdout = f"1500\t{path}\n"  # dst_after: pre-existing + transferred
-        elif cmd and cmd[0] == "rm":
-            rm_calls.append(cmd)
-        return r
-
     import tempfile, os as _os
+
     with tempfile.TemporaryDirectory() as root:
-        src_dir = _os.path.join(root, "disk5", "TV Shows", "Fire Country (2022)")
+        disk = _os.path.join(root, "disk5")
         hot_mount = _os.path.join(root, "zfs_media")
-        dst_dir = _os.path.join(hot_mount, "TV Shows", "Fire Country (2022)")
-        _os.makedirs(src_dir, exist_ok=True)
-        _os.makedirs(dst_dir, exist_ok=True)  # destination exists (pre-existing files)
+        src_file = _os.path.join(disk, "TV Shows", "Fire Country (2022)", "S02E01.mkv")
+        dst_file = _os.path.join(hot_mount, "TV Shows", "Fire Country (2022)", "S02E01.mkv")
+        preexisting = _os.path.join(hot_mount, "TV Shows", "Fire Country (2022)", "S01E01.mkv")
+        for f in (src_file, dst_file, preexisting):
+            _os.makedirs(_os.path.dirname(f), exist_ok=True)
+
+        with open(src_file, "wb") as f:
+            f.write(b"x" * 500)   # src = 500 bytes
+        with open(dst_file, "wb") as f:
+            f.write(b"x" * 500)   # dst = 500 bytes — matches
+        with open(preexisting, "wb") as f:
+            f.write(b"y" * 1000)  # pre-existing — NOT in warm_disk_files, not measured
+
+        def _fake_run(*_a, **_kw):
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()  # rsync no-op — files already in place
 
         item = _make_item(
             kind="series", library="TV Shows",
-            current_tier="WARM", current_disk=_os.path.join(root, "disk5"),
-            source_dirs=[src_dir],
+            current_tier="WARM", current_disk=disk,
+            warm_disk_files={disk: [src_file]},
         )
         item.outcome = "TO_HOT"
 
@@ -3560,8 +3574,10 @@ def _test_size_verify_mixed_tier_preexisting_dst_passes():
         finally:
             subprocess.run = orig
 
-    assert rm_calls, "rm -rf MUST be called — size verify should pass with delta logic"
-    assert dst_du_calls[0] == 2, f"expected 2 dst du calls (before + after), got {dst_du_calls[0]}"
+        assert not _os.path.exists(src_file), (
+            "source file must be deleted — verify should pass with file-level measurement"
+        )
+        assert _os.path.exists(preexisting), "pre-existing dst file must be untouched"
     print("_test_size_verify_mixed_tier_preexisting_dst_passes: OK")
 
 

--- a/tier.py
+++ b/tier.py
@@ -1756,10 +1756,23 @@ def _compute_destination_path(item: "Item", hot_pool_mount: str) -> Optional[str
 
 
 def _check_parity_in_progress() -> bool:
-    """Return True if an Unraid parity check or resync is running."""
+    """Return True if an Unraid parity check or resync is running.
+
+    Unraid uses a custom key=value /proc/mdstat format where mdResync= holds
+    the current sync position: 0 = idle, non-zero = in progress.
+    mdResyncAction= records the *last* action type regardless of run state,
+    so matching on the word "check" there gives a false positive when idle.
+
+    Standard Linux md RAID shows active progress inline as "check=22.3%".
+    """
     try:
         content = Path("/proc/mdstat").read_text()
-        return bool(re.search(r"\b(check|resync)\b", content))
+        # Unraid format: mdResync=<position>  (0 = idle)
+        m = re.search(r"^mdResync=(\d+)", content, re.MULTILINE)
+        if m:
+            return int(m.group(1)) > 0
+        # Standard Linux md format: active sync shows percentage inline.
+        return bool(re.search(r"\b(check|resync)\s*=\s*\d+\.\d+%", content))
     except OSError:
         return False
 
@@ -3286,6 +3299,49 @@ def _test_parity_check_aborts_pass():
     print("_test_parity_check_aborts_pass: OK")
 
 
+def _test_parity_check_unraid_idle_not_falsely_detected():
+    """Unraid idle mdstat (mdResync=0 + mdResyncAction=check) -> NOT detected as running.
+
+    Unraid stores the last action type in mdResyncAction regardless of whether
+    a check is actually running. mdResync=0 means idle; matching on the word
+    'check' in that field was a false positive.
+    """
+    import unittest.mock as _mock
+
+    idle_content = (
+        "mdResyncAction=check P\n"
+        "mdResyncSize=15625879500\n"
+        "mdResyncCorr=0\n"
+        "mdResync=0\n"
+        "mdResyncPos=0\n"
+        "mdResyncDt=0\n"
+        "mdResyncDb=0\n"
+    )
+    with _mock.patch.object(Path, "read_text", return_value=idle_content):
+        result = _check_parity_in_progress()
+    assert result is False, "idle Unraid mdstat must not be detected as parity check in progress"
+    print("_test_parity_check_unraid_idle_not_falsely_detected: OK")
+
+
+def _test_parity_check_unraid_active_detected():
+    """Unraid active check (mdResync=<non-zero>) -> correctly detected as running."""
+    import unittest.mock as _mock
+
+    active_content = (
+        "mdResyncAction=check P\n"
+        "mdResyncSize=15625879500\n"
+        "mdResyncCorr=0\n"
+        "mdResync=1234567890\n"
+        "mdResyncPos=1234567890\n"
+        "mdResyncDt=100\n"
+        "mdResyncDb=50\n"
+    )
+    with _mock.patch.object(Path, "read_text", return_value=active_content):
+        result = _check_parity_in_progress()
+    assert result is True, "active Unraid mdstat must be detected as parity check in progress"
+    print("_test_parity_check_unraid_active_detected: OK")
+
+
 def _test_size_verify_failure_skips_delete():
     """Size mismatch after rsync -> item marked FAILED, rm -rf NOT called."""
     rm_calls = []
@@ -3376,6 +3432,8 @@ if __name__ == "__main__":
         _test_move_skipped_when_already_hot()
         _test_dry_run_emits_no_apply_call()
         _test_parity_check_aborts_pass()
+        _test_parity_check_unraid_idle_not_falsely_detected()
+        _test_parity_check_unraid_active_detected()
         _test_size_verify_failure_skips_delete()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -169,6 +169,7 @@ DEFAULT_CONFIG = {
     # enabled: false means the move pass is skipped entirely — no log lines.
     "moves": {
         "enabled": False,
+        "apply": False,
         "rsync_options": ["-aH", "--partial", "--inplace"],
         "delete_source_after_verify": True,
         "size_verify": True,
@@ -376,7 +377,10 @@ class Item:
     # --- filled in at P1+ ---
     current_tier: str = "UNKNOWN"  # 'HOT' | 'WARM' | 'UNKNOWN'
     current_disk: Optional[str] = None  # dominant warm disk path; None if HOT/UNKNOWN/MIXED
-    source_dir: Optional[str] = None    # resolved local dir containing item's files on current_disk
+    # All warm disk source dirs for this item (dominant disk first). A series
+    # split across multiple array disks will have one entry per disk so the
+    # move executor can rsync every disk's content to the hot pool in one pass.
+    source_dirs: List[str] = field(default_factory=list)
     # --- decision ---
     outcome: str = "NEUTRAL"       # See decide_outcome() for P0 values
     # --- collection-pin support ---
@@ -675,7 +679,7 @@ def resolve_item_current_tier(
     hot_mount: str,
     array_disks: List[str],
     user_share_prefix: str = "",
-) -> Tuple[str, dict, Optional[str], Optional[str]]:
+) -> Tuple[str, dict, Optional[str], List[str]]:
     """Majority-bytes rollup of tier for a multi-part item.
 
     parts: iterable of (plex_file_path, size_bytes).
@@ -712,24 +716,31 @@ def resolve_item_current_tier(
                     disk_files.setdefault(disk, []).append(resolved)
                     break
     dominant = max(disk_bytes, key=disk_bytes.__getitem__) if disk_bytes else None
-    # Compute source_dir: common ancestor of all files on the dominant disk.
-    # For a single file /disk/Movies/Foo/foo.mkv → dirname → /disk/Movies/Foo.
-    # For multi-file: os.path.commonpath gives the shared directory already.
-    source_dir: Optional[str] = None
-    if dominant and disk_files.get(dominant):
-        files = disk_files[dominant]
+    # Build source dirs for every warm disk (dominant first). A series split
+    # across multiple array disks gets one entry per disk so the move executor
+    # can rsync all of them to the hot pool in one pass.
+    # For a single file /disk/Lib/Title/foo.mkv → dirname → /disk/Lib/Title.
+    # For multi-file commonpath already returns the shared directory.
+    warm_source_dirs: List[str] = []
+    for disk, files in disk_files.items():
+        if not files:
+            continue
         cp = os.path.commonpath(files)
-        source_dir = os.path.dirname(cp) if cp in files else cp
+        src = os.path.dirname(cp) if cp in files else cp
+        if disk == dominant:
+            warm_source_dirs.insert(0, src)
+        else:
+            warm_source_dirs.append(src)
     if total == 0:
-        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, None
+        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, []
     split = {k: round(v / total, 4) for k, v in totals.items()}
     if split["HOT"] > 0.5:
-        return "HOT", split, None, None
+        return "HOT", split, None, []
     if split["WARM"] > 0.5:
-        return "WARM", split, dominant, source_dir
+        return "WARM", split, dominant, warm_source_dirs
     if split["UNKNOWN"] > 0.5:
-        return "UNKNOWN", split, None, None
-    return "MIXED", split, dominant, source_dir
+        return "UNKNOWN", split, None, []
+    return "MIXED", split, dominant, warm_source_dirs
 
 
 def _media_parts(media_list) -> Iterable[Tuple[str, int]]:
@@ -1307,13 +1318,13 @@ def collect_movies(
         # Current tier (P1). Probes only if tier detection is configured.
         current_tier = "UNKNOWN"
         current_disk: Optional[str] = None
-        source_dir: Optional[str] = None
+        source_dirs: List[str] = []
         tier_split: Optional[dict] = None
         if tier_probing:
             parts = []
             for m in group:
                 parts.extend(_media_parts(getattr(m, "media", None)))
-            current_tier, tier_split, current_disk, source_dir = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1336,7 +1347,7 @@ def collect_movies(
             score=score,
             current_tier=current_tier,
             current_disk=current_disk,
-            source_dir=source_dir,
+            source_dirs=source_dirs,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=primary_rk,
             recently_added=recently_added,
@@ -1417,13 +1428,13 @@ def collect_series(
         # Current tier (P1): majority-bytes rollup across every episode.
         current_tier = "UNKNOWN"
         current_disk: Optional[str] = None
-        source_dir: Optional[str] = None
+        source_dirs: List[str] = []
         tier_split: Optional[dict] = None
         if tier_probing:
             parts = []
             for ep in episodes:
                 parts.extend(_media_parts(getattr(ep, "media", None)))
-            current_tier, tier_split, current_disk, source_dir = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1441,7 +1452,7 @@ def collect_series(
             score=score,
             current_tier=current_tier,
             current_disk=current_disk,
-            source_dir=source_dir,
+            source_dirs=source_dirs,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=rk,
             recently_added=recently_added,
@@ -1742,16 +1753,19 @@ _ASSUMED_THROUGHPUT_BPS = 200 * 1024 * 1024  # 200 MB/s
 def _compute_destination_path(item: "Item", hot_pool_mount: str) -> Optional[str]:
     """Return the hot-pool path for a TO_HOT move.
 
-    Strips item.current_disk prefix from item.source_dir and prepends
-    hot_pool_mount. Returns None if source_dir or current_disk is unset
-    or inconsistent (logged by caller).
+    Uses the dominant (first) source dir to derive the relative path, then
+    prepends hot_pool_mount. All source dirs share the same relative path
+    (e.g. /TV Shows/Show (2001)) so the destination is the same regardless
+    of which disk each source dir lives on.
+    Returns None if source_dirs is empty or current_disk is unset.
     """
-    if not item.source_dir or not item.current_disk:
+    if not item.source_dirs or not item.current_disk:
         return None
+    src = item.source_dirs[0]
     disk = item.current_disk.rstrip("/")
-    if not item.source_dir.startswith(disk + "/") and item.source_dir != disk:
+    if not src.startswith(disk + "/") and src != disk:
         return None
-    rel = item.source_dir[len(disk):]
+    rel = src[len(disk):]
     return hot_pool_mount.rstrip("/") + rel
 
 
@@ -1809,45 +1823,46 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     to_hot = [it for it in items if it.outcome == "TO_HOT"]
 
-    # Resolve source/destination for each candidate.
-    moves: List[tuple] = []  # (item, src, dst)
+    # Resolve destination for each candidate. Items already on HOT are kept
+    # in the list so the per-item loop can emit [SKIPPED] with their index.
+    moves: List[tuple] = []  # (item, dst_or_None)
     for it in to_hot:
         if it.current_tier == "HOT":
-            # Already on hot pool — handled as [SKIPPED] in the loop below.
-            moves.append((it, it.source_dir, None))
+            moves.append((it, None))
             continue
         dst = _compute_destination_path(it, hot_mount)
         if dst is None:
             log.warning(
                 "Moves: [SKIP] %s — cannot compute destination "
-                "(source_dir=%r current_disk=%r)",
-                it.title_year, it.source_dir, it.current_disk,
+                "(source_dirs=%r current_disk=%r)",
+                it.title_year, it.source_dirs, it.current_disk,
             )
             continue
-        moves.append((it, it.source_dir, dst))
+        moves.append((it, dst))
 
     if not moves:
         log.info("Moves: no actionable TO_HOT items")
         return
 
-    total_bytes = sum(it.size_bytes for it, _, dst in moves if dst is not None)
+    total_bytes = sum(it.size_bytes for it, dst in moves if dst is not None)
 
     if not apply:
         eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
         log.info(
             "[DRY-RUN] Moves: TO_HOT=%d — %s total — estimated %s at 200 MB/s",
-            len([m for m in moves if m[2] is not None]),
+            len([m for m in moves if m[1] is not None]),
             _fmt_size(total_bytes / (1024 ** 3)),
             eta,
         )
-        for it, src, dst in moves:
+        for it, dst in moves:
             if dst is None:
                 log.info("[DRY-RUN]   %s — already on hot pool (SKIPPED)", it.title_year)
             else:
-                log.info(
-                    "[DRY-RUN]   %s — %s — %s → %s",
-                    it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)), src, dst,
-                )
+                for src in it.source_dirs:
+                    log.info(
+                        "[DRY-RUN]   %s — %s — %s → %s",
+                        it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)), src, dst,
+                    )
         return
 
     # --apply mode.
@@ -1876,54 +1891,65 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     affected_libraries: set = set()
     run_start = datetime.now(timezone.utc)
 
-    for idx, (it, src, dst) in enumerate(moves, 1):
+    for idx, (it, dst) in enumerate(moves, 1):
         prefix = f"  [{idx}/{len(moves)}]"
         item_start = datetime.now(timezone.utc)
+        size_str = _fmt_size(it.size_bytes / (1024 ** 3))
 
         if dst is None or it.current_tier == "HOT":
             log.info("%s [SKIPPED] %s — already on hot pool (no-op)", prefix, it.title_year)
             n_skipped += 1
             continue
 
+        # Log before starting — long rsyncs are otherwise silent.
+        log.info("%s Moving %s — %s", prefix, it.title_year, size_str)
+        for src in it.source_dirs:
+            log.info("%s   %s → %s", prefix, src, dst)
+
         # Ensure destination parent directory exists.
         dst_parent = str(Path(dst).parent)
         try:
             Path(dst_parent).mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            log.error(
-                "%s [FAILED] %s — cannot create %s: %s",
-                prefix, it.title_year, dst_parent, exc,
-            )
+            log.error("%s [FAILED] %s — cannot create %s: %s", prefix, it.title_year, dst_parent, exc)
             n_failed += 1
             continue
 
-        # rsync source directory into destination.
-        cmd = ["rsync"] + rsync_opts + [src.rstrip("/") + "/", dst.rstrip("/") + "/"]
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
-        except OSError as exc:
-            log.error("%s [FAILED] %s — rsync failed to start: %s", prefix, it.title_year, exc)
+        # rsync each source directory (one per warm disk) into the destination.
+        rsync_failed = False
+        for src in it.source_dirs:
+            cmd = ["rsync"] + rsync_opts + [src.rstrip("/") + "/", dst.rstrip("/") + "/"]
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True)
+            except OSError as exc:
+                log.error("%s [FAILED] %s — rsync failed to start: %s", prefix, it.title_year, exc)
+                rsync_failed = True
+                break
+            if result.returncode != 0:
+                log.error(
+                    "%s [FAILED] %s — rsync exit %d (%s) — source unchanged",
+                    prefix, it.title_year, result.returncode, src,
+                )
+                rsync_failed = True
+                break
+        if rsync_failed:
             n_failed += 1
             continue
 
-        if result.returncode != 0:
-            log.error(
-                "%s [FAILED] %s — rsync exit %d — source unchanged",
-                prefix, it.title_year, result.returncode,
-            )
-            n_failed += 1
-            continue
-
-        # Size verification.
+        # Size verification: sum all source dirs, compare to destination total.
         if size_verify:
             try:
-                src_du = subprocess.run(["du", "-sb", src], capture_output=True, text=True)
+                src_sz = 0
+                for src in it.source_dirs:
+                    du = subprocess.run(["du", "-sb", src], capture_output=True, text=True)
+                    if du.returncode != 0:
+                        raise OSError(f"du failed for {src}")
+                    src_sz += int(du.stdout.split()[0])
                 dst_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
-                src_sz = int(src_du.stdout.split()[0]) if src_du.returncode == 0 else None
                 dst_sz = int(dst_du.stdout.split()[0]) if dst_du.returncode == 0 else None
-                if src_sz is None or dst_sz is None or abs(src_sz - dst_sz) > 1024:
+                if dst_sz is None or abs(src_sz - dst_sz) > 1024:
                     log.error(
-                        "%s [FAILED] %s — size verify failed (src=%s dst=%s) — source unchanged",
+                        "%s [FAILED] %s — size verify failed (src_total=%s dst=%s) — source unchanged",
                         prefix, it.title_year, src_sz, dst_sz,
                     )
                     n_failed += 1
@@ -1936,17 +1962,19 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
                 n_failed += 1
                 continue
 
-        # Delete source if configured.
+        # Delete all source directories if configured.
         if delete_after:
-            try:
-                subprocess.run(["rm", "-rf", src], check=True, capture_output=True)
-            except subprocess.CalledProcessError as exc:
-                elapsed = (datetime.now(timezone.utc) - item_start).total_seconds()
-                log.warning(
-                    "%s [SUCCESS*] %s — %s in %s — moved OK but source removal failed: %s",
-                    prefix, it.title_year,
-                    _fmt_size(it.size_bytes / (1024 ** 3)), _fmt_eta(elapsed), exc,
-                )
+            delete_failed = False
+            for src in it.source_dirs:
+                try:
+                    subprocess.run(["rm", "-rf", src], check=True, capture_output=True)
+                except subprocess.CalledProcessError as exc:
+                    log.warning(
+                        "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
+                        prefix, it.title_year, src, exc,
+                    )
+                    delete_failed = True
+            if delete_failed:
                 n_success += 1
                 affected_libraries.add(it.library)
                 continue
@@ -1954,8 +1982,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         elapsed = (datetime.now(timezone.utc) - item_start).total_seconds()
         log.info(
             "%s [SUCCESS] %s — %s in %s — %s → %s",
-            prefix, it.title_year,
-            _fmt_size(it.size_bytes / (1024 ** 3)), _fmt_eta(elapsed),
+            prefix, it.title_year, size_str, _fmt_eta(elapsed),
             it.current_disk, hot_mount,
         )
         n_success += 1
@@ -2225,7 +2252,8 @@ def _run(args) -> int:
 
     # Move pass runs on the full scored list before --top truncation so every
     # TO_HOT item is considered regardless of display limit.
-    _run_move_pass(items, cfg, apply=args.apply)
+    moves_apply = args.apply or bool((cfg.get("moves") or {}).get("apply", False))
+    _run_move_pass(items, cfg, apply=moves_apply)
 
     if args.top:
         items = items[: args.top]
@@ -3155,7 +3183,7 @@ def _test_destination_path_movie_tohot():
     item = _make_item(
         kind="movie", library="Movies", title="Foo", year=2010,
         current_disk="/mnt/disk4",
-        source_dir="/mnt/disk4/Movies/Foo (2010)",
+        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
     )
     dst = _compute_destination_path(item, "/mnt/zfs_media")
     assert dst == "/mnt/zfs_media/Movies/Foo (2010)", f"got {dst!r}"
@@ -3167,7 +3195,7 @@ def _test_destination_path_series_tohot():
     item = _make_item(
         kind="series", library="TV Shows", title="Show", year=2001,
         current_disk="/mnt/disk2",
-        source_dir="/mnt/disk2/TV Shows/Show (2001)",
+        source_dirs=["/mnt/disk2/TV Shows/Show (2001)"],
     )
     dst = _compute_destination_path(item, "/mnt/zfs_media")
     assert dst == "/mnt/zfs_media/TV Shows/Show (2001)", f"got {dst!r}"
@@ -3188,7 +3216,7 @@ def _test_move_skipped_when_already_hot():
     item = _make_item(
         kind="movie", library="Movies",
         current_tier="HOT", current_disk="/mnt/disk4",
-        source_dir="/mnt/disk4/Movies/Foo (2010)",
+        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
     )
     item.outcome = "TO_HOT"
 
@@ -3227,7 +3255,7 @@ def _test_dry_run_emits_no_apply_call():
     item = _make_item(
         kind="movie", library="Movies",
         current_tier="WARM", current_disk="/mnt/disk4",
-        source_dir="/mnt/disk4/Movies/Foo (2010)",
+        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
     )
     item.outcome = "TO_HOT"
 
@@ -3268,7 +3296,7 @@ def _test_parity_check_aborts_pass():
     item = _make_item(
         kind="movie", library="Movies",
         current_tier="WARM", current_disk="/mnt/disk4",
-        source_dir="/mnt/disk4/Movies/Foo (2010)",
+        source_dirs=["/mnt/disk4/Movies/Foo (2010)"],
     )
     item.outcome = "TO_HOT"
 
@@ -3371,7 +3399,7 @@ def _test_size_verify_failure_skips_delete():
         item = _make_item(
             kind="movie", library="Movies",
             current_tier="WARM", current_disk=_os.path.join(root, "disk4"),
-            source_dir=src,
+            source_dirs=[src],
         )
         item.outcome = "TO_HOT"
 
@@ -3393,6 +3421,57 @@ def _test_size_verify_failure_skips_delete():
 
     assert not rm_calls, f"rm -rf must NOT be called on size mismatch, got {rm_calls}"
     print("_test_size_verify_failure_skips_delete: OK")
+
+
+def _test_multidisk_series_all_source_dirs_rsynced():
+    """Series split across two warm disks: rsync is called once per source dir."""
+    import tempfile, os as _os
+
+    rsync_srcs = []
+
+    def _fake_run(cmd, **_):
+        class R:
+            returncode = 0
+            stdout = "1000000\t/path"
+        if cmd and cmd[0] == "rsync":
+            rsync_srcs.append(cmd[-2])
+        return R()
+
+    with tempfile.TemporaryDirectory() as root:
+        disk6_src = _os.path.join(root, "disk6", "TV Shows", "Reba (2001)")
+        disk3_src = _os.path.join(root, "disk3", "TV Shows", "Reba (2001)")
+        hot_mount = _os.path.join(root, "zfs_media")
+        _os.makedirs(disk6_src, exist_ok=True)
+        _os.makedirs(disk3_src, exist_ok=True)
+        _os.makedirs(hot_mount, exist_ok=True)
+
+        item = _make_item(
+            kind="series", library="TV Shows", title="Reba", year=2001,
+            current_tier="WARM", current_disk=_os.path.join(root, "disk6"),
+            source_dirs=[disk6_src, disk3_src],
+        )
+        item.outcome = "TO_HOT"
+
+        cfg = {
+            "moves": {
+                "enabled": True, "rsync_options": ["-aH"],
+                "delete_source_after_verify": False, "size_verify": False,
+                "parity_check_blocking": False, "bandwidth_limit_mbps": None,
+            },
+            "paths": {"hot_pool_mount": hot_mount},
+        }
+
+        orig = subprocess.run
+        try:
+            subprocess.run = _fake_run
+            _run_move_pass([item], cfg, apply=True)
+        finally:
+            subprocess.run = orig
+
+    assert len(rsync_srcs) == 2, f"expected 2 rsync calls, got {len(rsync_srcs)}: {rsync_srcs}"
+    assert any("disk6" in s for s in rsync_srcs), "disk6 source missing from rsync calls"
+    assert any("disk3" in s for s in rsync_srcs), "disk3 source missing from rsync calls"
+    print("_test_multidisk_series_all_source_dirs_rsynced: OK")
 
 
 if __name__ == "__main__":
@@ -3435,5 +3514,6 @@ if __name__ == "__main__":
         _test_parity_check_unraid_idle_not_falsely_detected()
         _test_parity_check_unraid_active_detected()
         _test_size_verify_failure_skips_delete()
+        _test_multidisk_series_all_source_dirs_rsynced()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -677,6 +677,36 @@ def classify_path(
     return "UNKNOWN"
 
 
+def _find_companion_files(media_path: str) -> List[str]:
+    """Return sidecar files in the same directory that share the media file's stem.
+
+    Plex discovers external subtitles at play time by scanning the media
+    file's directory for files whose stem matches (or starts with the stem
+    followed by '.', to catch language tags like Movie.en.srt).  This
+    function replicates that logic so rsync moves companions alongside the
+    media file.
+
+    Example: /disk/Movies/Moana (2016).mkv  →  finds:
+      Moana (2016).nfo, Moana (2016).en.srt, Moana (2016).sub, …
+    """
+    parent = os.path.dirname(media_path)
+    stem = os.path.splitext(os.path.basename(media_path))[0]
+    companions: List[str] = []
+    try:
+        with os.scandir(parent) as it:
+            for entry in it:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if entry.path == media_path:
+                    continue
+                entry_stem = os.path.splitext(entry.name)[0]
+                if entry_stem == stem or entry_stem.startswith(stem + "."):
+                    companions.append(entry.path)
+    except OSError:
+        pass
+    return companions
+
+
 def resolve_item_current_tier(
     parts: Iterable[Tuple[str, int]],
     path_map,
@@ -720,6 +750,20 @@ def resolve_item_current_tier(
                     disk_bytes[disk] = disk_bytes.get(disk, 0) + size
                     disk_files.setdefault(disk, []).append(resolved)
                     break
+    # Augment each disk's file list with companion files (subtitles, NFO, etc.)
+    # that share the media file's stem. Plex discovers external subtitles this
+    # way at play time, so they must live alongside the media on the same tier.
+    seen: set = set()
+    for disk in list(disk_files.keys()):
+        extras: List[str] = []
+        for mf in disk_files[disk]:
+            seen.add(mf)
+            for companion in _find_companion_files(mf):
+                if companion not in seen:
+                    seen.add(companion)
+                    extras.append(companion)
+        disk_files[disk].extend(extras)
+
     dominant = max(disk_bytes, key=disk_bytes.__getitem__) if disk_bytes else None
     # Build display-only source dirs (common ancestor per disk, dominant first).
     warm_source_dirs: List[str] = []
@@ -3581,6 +3625,44 @@ def _test_size_verify_mixed_tier_preexisting_dst_passes():
     print("_test_size_verify_mixed_tier_preexisting_dst_passes: OK")
 
 
+def _test_companion_files_included_in_warm_disk_files():
+    """Companion files (nfo, srt, sub) are included in warm_disk_files alongside media."""
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk = _os.path.join(root, "disk4")
+        hot_mount = _os.path.join(root, "zfs_media")
+        movie_dir = _os.path.join(disk, "Movies", "Moana (2016)")
+        _os.makedirs(movie_dir, exist_ok=True)
+        _os.makedirs(hot_mount, exist_ok=True)
+
+        mkv = _os.path.join(movie_dir, "Moana (2016).mkv")
+        nfo = _os.path.join(movie_dir, "Moana (2016).nfo")
+        srt = _os.path.join(movie_dir, "Moana (2016).en.srt")
+        unrelated = _os.path.join(movie_dir, "other_movie.mkv")
+
+        for f in (mkv, nfo, srt, unrelated):
+            with open(f, "wb") as fh:
+                fh.write(b"x" * 100)
+
+        parts = [(mkv, 100)]
+        tier, _, _, _, wdf = resolve_item_current_tier(
+            parts=parts,
+            path_map=[],
+            hot_mount=hot_mount,
+            array_disks=[disk],
+        )
+
+        assert tier == "WARM", f"expected WARM, got {tier}"
+        files = wdf.get(disk, [])
+        assert mkv in files, f"mkv missing from warm_disk_files: {files}"
+        assert nfo in files, f"nfo missing from warm_disk_files: {files}"
+        assert srt in files, f"srt missing from warm_disk_files: {files}"
+        assert unrelated not in files, f"unrelated file must not be included: {files}"
+
+    print("_test_companion_files_included_in_warm_disk_files: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -3623,5 +3705,6 @@ if __name__ == "__main__":
         _test_size_verify_failure_skips_delete()
         _test_multidisk_series_all_source_dirs_rsynced()
         _test_size_verify_mixed_tier_preexisting_dst_passes()
+        _test_companion_files_included_in_warm_disk_files()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -1915,6 +1915,17 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             n_failed += 1
             continue
 
+        # Snapshot destination size before rsync. Items that were MIXED-tier may
+        # already have some files on the hot pool; we compare the delta (bytes
+        # added) against the source size, not the absolute destination total.
+        dst_before_sz = 0
+        if size_verify and Path(dst).exists():
+            try:
+                pre_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
+                dst_before_sz = int(pre_du.stdout.split()[0]) if pre_du.returncode == 0 else 0
+            except Exception:  # noqa: BLE001
+                dst_before_sz = 0
+
         # rsync each source directory (one per warm disk) into the destination.
         rsync_failed = False
         for src in it.source_dirs:
@@ -1926,9 +1937,12 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
                 rsync_failed = True
                 break
             if result.returncode != 0:
+                stderr_lines = (result.stderr or "").strip().splitlines()[:5]
+                stderr_str = "; ".join(stderr_lines) if stderr_lines else ""
                 log.error(
-                    "%s [FAILED] %s — rsync exit %d (%s) — source unchanged",
+                    "%s [FAILED] %s — rsync exit %d (%s)%s — source unchanged",
                     prefix, it.title_year, result.returncode, src,
+                    f": {stderr_str}" if stderr_str else "",
                 )
                 rsync_failed = True
                 break
@@ -1936,7 +1950,9 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             n_failed += 1
             continue
 
-        # Size verification: sum all source dirs, compare to destination total.
+        # Size verification: compare bytes transferred (dst delta) against source.
+        # Using the delta rather than absolute dst size handles items that were
+        # MIXED-tier (some files already on hot pool before this run).
         if size_verify:
             try:
                 src_sz = 0
@@ -1946,11 +1962,14 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
                         raise OSError(f"du failed for {src}")
                     src_sz += int(du.stdout.split()[0])
                 dst_du = subprocess.run(["du", "-sb", dst], capture_output=True, text=True)
-                dst_sz = int(dst_du.stdout.split()[0]) if dst_du.returncode == 0 else None
-                if dst_sz is None or abs(src_sz - dst_sz) > 1024:
+                dst_after_sz = int(dst_du.stdout.split()[0]) if dst_du.returncode == 0 else None
+                transferred = (dst_after_sz - dst_before_sz) if dst_after_sz is not None else None
+                if transferred is None or abs(transferred - src_sz) > 1024:
                     log.error(
-                        "%s [FAILED] %s — size verify failed (src_total=%s dst=%s) — source unchanged",
-                        prefix, it.title_year, src_sz, dst_sz,
+                        "%s [FAILED] %s — size verify failed "
+                        "(src=%s dst_delta=%s dst_before=%s dst_after=%s) — source unchanged",
+                        prefix, it.title_year, src_sz, transferred,
+                        dst_before_sz, dst_after_sz,
                     )
                     n_failed += 1
                     continue
@@ -3474,6 +3493,78 @@ def _test_multidisk_series_all_source_dirs_rsynced():
     print("_test_multidisk_series_all_source_dirs_rsynced: OK")
 
 
+def _test_size_verify_mixed_tier_preexisting_dst_passes():
+    """MIXED-tier item: destination already has pre-existing files before rsync.
+
+    Old logic compared src_sz vs dst_total and always failed (dst > src).
+    New logic compares src_sz vs (dst_after - dst_before) so pre-existing
+    content doesn't count as a mismatch.
+
+    Fake du returns: src=500B, dst_before=1000B (pre-existing), dst_after=1500B.
+    delta = 1500-1000 = 500 == src → verify passes → rm is called.
+    """
+    rm_calls = []
+    # Track dst du calls so we can return different values before/after rsync.
+    dst_du_calls = [0]
+
+    def _fake_run(cmd, **_):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if cmd and cmd[0] == "rsync":
+            pass  # success, no-op
+        elif cmd and cmd[0] == "du":
+            path = cmd[-1]
+            if "disk5" in path:
+                r.stdout = f"500\t{path}\n"       # source bytes
+            else:
+                dst_du_calls[0] += 1
+                if dst_du_calls[0] == 1:
+                    r.stdout = f"1000\t{path}\n"  # dst_before: pre-existing
+                else:
+                    r.stdout = f"1500\t{path}\n"  # dst_after: pre-existing + transferred
+        elif cmd and cmd[0] == "rm":
+            rm_calls.append(cmd)
+        return r
+
+    import tempfile, os as _os
+    with tempfile.TemporaryDirectory() as root:
+        src_dir = _os.path.join(root, "disk5", "TV Shows", "Fire Country (2022)")
+        hot_mount = _os.path.join(root, "zfs_media")
+        dst_dir = _os.path.join(hot_mount, "TV Shows", "Fire Country (2022)")
+        _os.makedirs(src_dir, exist_ok=True)
+        _os.makedirs(dst_dir, exist_ok=True)  # destination exists (pre-existing files)
+
+        item = _make_item(
+            kind="series", library="TV Shows",
+            current_tier="WARM", current_disk=_os.path.join(root, "disk5"),
+            source_dirs=[src_dir],
+        )
+        item.outcome = "TO_HOT"
+
+        cfg = {
+            "moves": {
+                "enabled": True, "rsync_options": ["-aH"],
+                "delete_source_after_verify": True, "size_verify": True,
+                "parity_check_blocking": False, "bandwidth_limit_mbps": None,
+            },
+            "paths": {"hot_pool_mount": hot_mount},
+        }
+
+        orig = subprocess.run
+        try:
+            subprocess.run = _fake_run
+            _run_move_pass([item], cfg, apply=True)
+        finally:
+            subprocess.run = orig
+
+    assert rm_calls, "rm -rf MUST be called — size verify should pass with delta logic"
+    assert dst_du_calls[0] == 2, f"expected 2 dst du calls (before + after), got {dst_du_calls[0]}"
+    print("_test_size_verify_mixed_tier_preexisting_dst_passes: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -3515,5 +3606,6 @@ if __name__ == "__main__":
         _test_parity_check_unraid_active_detected()
         _test_size_verify_failure_skips_delete()
         _test_multidisk_series_all_source_dirs_rsynced()
+        _test_size_verify_mixed_tier_preexisting_dst_passes()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -2036,25 +2036,35 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         # items sharing the same parent directory (e.g. a year folder) are safe.
         if delete_after:
             delete_failed = False
-            dirs_to_prune: set = set()
+            # Per-disk set of leaf dirs that need ancestor pruning.
+            disk_leaf_dirs: Dict[str, set] = {}
             for disk, files in it.warm_disk_files.items():
+                disk_leaf_dirs[disk] = set()
                 for f in files:
                     try:
                         os.unlink(f)
-                        dirs_to_prune.add(os.path.dirname(f))
+                        disk_leaf_dirs[disk].add(os.path.dirname(f))
                     except OSError as exc:
                         log.warning(
                             "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
                             prefix, it.title_year, f, exc,
                         )
                         delete_failed = True
-            # Prune empty ancestor directories up to (but not including) disk root.
-            for d in sorted(dirs_to_prune, reverse=True):
-                disk_root = (it.current_disk or "").rstrip("/")
-                if d == disk_root or not d.startswith(disk_root):
-                    continue
+            # Prune empty ancestor directories up to (but not including) each
+            # disk root. Walk every ancestor so season dirs, show dirs, etc.
+            # are removed when they empty out. Each disk is handled with its
+            # own root so multi-disk series prune correctly on every disk.
+            all_dirs: set = set()
+            for disk, leaf_dirs in disk_leaf_dirs.items():
+                disk_root = disk.rstrip("/")
+                for d in leaf_dirs:
+                    current = d
+                    while current and current != disk_root and current.startswith(disk_root + "/"):
+                        all_dirs.add(current)
+                        current = os.path.dirname(current)
+            for d in sorted(all_dirs, reverse=True):
                 try:
-                    os.rmdir(d)  # no-op if directory still has files
+                    os.rmdir(d)  # no-op if directory still has content
                 except OSError:
                     pass
             if delete_failed:
@@ -3625,6 +3635,77 @@ def _test_size_verify_mixed_tier_preexisting_dst_passes():
     print("_test_size_verify_mixed_tier_preexisting_dst_passes: OK")
 
 
+def _test_empty_ancestor_dirs_pruned_after_delete():
+    """Season dir, show dir, and intermediate dirs are removed when emptied by a move.
+
+    Simulates a TV series where Season 1 lives on disk1 (non-dominant) and Season 2
+    on disk5 (dominant). After all files are deleted, both season dirs and both show
+    dirs must be pruned, not just the immediate parent of each file.
+    """
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk1 = _os.path.join(root, "disk1")
+        disk5 = _os.path.join(root, "disk5")
+        hot_mount = _os.path.join(root, "zfs_media")
+
+        s1_ep = _os.path.join(disk1, "TV Shows", "Sullivan's Crossing (2023)", "Season 1", "S01E01.mkv")
+        s2_ep = _os.path.join(disk5, "TV Shows", "Sullivan's Crossing (2023)", "Season 2", "S02E01.mkv")
+        dst_s1 = _os.path.join(hot_mount, "TV Shows", "Sullivan's Crossing (2023)", "Season 1", "S01E01.mkv")
+        dst_s2 = _os.path.join(hot_mount, "TV Shows", "Sullivan's Crossing (2023)", "Season 2", "S02E01.mkv")
+
+        for f in (s1_ep, s2_ep, dst_s1, dst_s2):
+            _os.makedirs(_os.path.dirname(f), exist_ok=True)
+            with open(f, "wb") as fh:
+                fh.write(b"x" * 100)
+
+        def _fake_run(*_a, **_kw):
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        item = _make_item(
+            kind="series", library="TV Shows",
+            current_tier="WARM", current_disk=disk5,
+            warm_disk_files={disk1: [s1_ep], disk5: [s2_ep]},
+        )
+        item.outcome = "TO_HOT"
+
+        cfg = {
+            "moves": {
+                "enabled": True, "rsync_options": ["-aH"],
+                "delete_source_after_verify": True, "size_verify": True,
+                "parity_check_blocking": False, "bandwidth_limit_mbps": None,
+            },
+            "paths": {"hot_pool_mount": hot_mount},
+        }
+
+        orig = subprocess.run
+        try:
+            subprocess.run = _fake_run
+            _run_move_pass([item], cfg, apply=True)
+        finally:
+            subprocess.run = orig
+
+        # Files must be gone
+        assert not _os.path.exists(s1_ep), "S01E01.mkv source must be deleted"
+        assert not _os.path.exists(s2_ep), "S02E01.mkv source must be deleted"
+        # Season dirs must be pruned (were empty after file deletion)
+        assert not _os.path.exists(_os.path.dirname(s1_ep)), "Season 1 dir on disk1 must be pruned"
+        assert not _os.path.exists(_os.path.dirname(s2_ep)), "Season 2 dir on disk5 must be pruned"
+        # Show dirs must be pruned (became empty after season dirs removed)
+        show_disk1 = _os.path.join(disk1, "TV Shows", "Sullivan's Crossing (2023)")
+        show_disk5 = _os.path.join(disk5, "TV Shows", "Sullivan's Crossing (2023)")
+        assert not _os.path.exists(show_disk1), "show dir on disk1 must be pruned"
+        assert not _os.path.exists(show_disk5), "show dir on disk5 must be pruned"
+        # Disk roots themselves must never be touched
+        assert _os.path.exists(disk1), "disk1 root must survive"
+        assert _os.path.exists(disk5), "disk5 root must survive"
+
+    print("_test_empty_ancestor_dirs_pruned_after_delete: OK")
+
+
 def _test_companion_files_included_in_warm_disk_files():
     """Companion files (nfo, srt, sub) are included in warm_disk_files alongside media."""
     import tempfile, os as _os
@@ -3706,5 +3787,6 @@ if __name__ == "__main__":
         _test_multidisk_series_all_source_dirs_rsynced()
         _test_size_verify_mixed_tier_preexisting_dst_passes()
         _test_companion_files_included_in_warm_disk_files()
+        _test_empty_ancestor_dirs_pruned_after_delete()
         sys.exit(0)
     sys.exit(main())


### PR DESCRIPTION
## Summary

Turns the dry-run analyser into a doer. Introduces the move executor for the TO_HOT direction — rsync from the warm Unraid parity array to the hot ZFS pool. Default behaviour is still dry-run (no `--apply`); `--apply` + `moves.enabled: true` executes moves serially.

## Config schema

```yaml
moves:
  enabled: false                                    # default off — opt-in
  rsync_options: ["-aH", "--partial", "--inplace"]  # tunable
  delete_source_after_verify: true                  # set false for first runs
  size_verify: true                                 # verify dest size matches src before delete
  parity_check_blocking: true                       # abort if Unraid parity check is running
  bandwidth_limit_mbps: null                        # null = unthrottled
```

## Behaviour

- **`moves.enabled: false`** (default) — move pass skipped entirely, no log lines, dry-run report unaffected
- **`moves.enabled: true`, no `--apply`** — `[DRY-RUN]` block logs every projected TO_HOT move with source path, destination path, size, and ETA estimate at 200 MB/s
- **`moves.enabled: true`, `--apply`** — moves execute serially; per-item `[SUCCESS]` / `[SKIPPED]` / `[FAILED]` log lines with elapsed time
- **Parity guard** — reads `/proc/mdstat` before starting; aborts (or warns if `parity_check_blocking: false`) if a check/resync is running
- **Size verify** — `du -sb` on source and destination after rsync; mismatch > 1 KB fails the item, source is NOT deleted
- **Source delete** — only after rsync exit 0 AND size-verify pass, when `delete_source_after_verify: true`
- **Scope** — TO_HOT only; TO_WARM / RELOCATE_WARM / SHOULD_BE_* items are tallied in a single skip line (P2.2/P2.3)
- **Already-HOT guard** — TO_HOT items whose `current_tier` is already HOT log `[SKIPPED]` and skip rsync (idempotency net for re-runs after partial apply)
- **`Item.source_dir`** — new field: common-ancestor directory of all resolved files on the dominant WARM disk; drives destination path computation

## Tests

Six new inline tests, all passing (`python3 tier.py --_test`):

- `_test_destination_path_movie_tohot` — movie destination = `hot_pool_mount/library/title_year`
- `_test_destination_path_series_tohot` — series equivalent
- `_test_move_skipped_when_already_hot` — already-HOT item → SKIPPED, no rsync call
- `_test_dry_run_emits_no_apply_call` — dry-run path makes zero subprocess calls
- `_test_parity_check_aborts_pass` — stubbed `/proc/mdstat` with active check → move pass aborts before rsync
- `_test_size_verify_failure_skips_delete` — mismatched `du` sizes → `rm -rf` NOT called, item logged FAILED

37 total tests pass.

## Docs

- **README.md** — new "Moves (P2)" section covering dry-run vs apply, scope, source deletion, parity guard, bandwidth throttle, and recommended first-run sequence; updated phase table; removed stale exit code 3
- **AGENTS.md** — new "Move executor (P2.1)" design decisions subsection (why TO_HOT first, why size-verify gates delete, why serial, why parity blocks, why already-HOT is an idempotency net, `source_dir` derivation); updated phase table and dev rules
- **example.tiering.yaml** — `moves:` block with all keys, defaults, and per-key comments

## Test plan

- [ ] Pull this branch, leave `moves.enabled: false`. Run. Confirm no `Moves:` lines in output.
- [ ] Set `moves.enabled: true`, leave `--apply` off. Run. Confirm `[DRY-RUN]` block appears with item-level paths and aggregate total + ETA.
- [ ] Confirm `tier.log` contains the same dry-run output.
- [ ] Set `delete_source_after_verify: false`. Run with `--apply` on a single small test item. Confirm destination has the file; source still exists.
- [ ] Re-run the same item with `delete_source_after_verify: true`. Confirm source is deleted post-verify.
- [ ] Trigger a parity check from the Unraid GUI, then run with `--apply`. Confirm the run aborts with the parity-check error before any rsync.
- [ ] Spot-check Plex: confirm the moved file still plays (Unraid's FUSE union view hides the physical move from Plex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)