### PR TITLE
docs(AGENTS): PR flow, venv test command, CI trust guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,9 +546,7 @@ git checkout -b feat/p2.2-to-warm-moves
 git add tier.py example.tiering.yaml README.md AGENTS.md
 git commit -m "feat(P2.2): TO_WARM + RELOCATE_WARM move directions
 
-Brief body: what changed and why. One paragraph max.
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Brief body: what changed and why. One paragraph max."
 
 # 5. Push
 git push -u origin feat/p2.2-to-warm-moves
@@ -583,8 +581,6 @@ What was updated in README, AGENTS.md, example.tiering.yaml.
 Checkboxes for manual on-Unraid verification steps (only when the
 change touches Plex API semantics or real filesystem behaviour —
 see "When to trust CI vs require Unraid testing" above).
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
 Check for an existing issue with `gh issue list` before opening the PR; if

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,22 +438,44 @@ revocation event, not a quick fix.
 #### Automated in CI
 
 Every push and pull request targeting `main` runs `.github/workflows/test.yml`,
-which executes the three checks below automatically. A failing check blocks
-PR merge (once branch protection is enabled). You do not need to run these
+which executes `py_compile`, the YAML validity check, and `--_test`
+automatically. A failing check blocks PR merge. You do not need to run these
 as a manual ritual, but running them locally first gives a fast-fail loop
 before waiting for CI.
 
+#### When to trust CI vs require Unraid testing
+
+CI is sufficient to merge when the change is **purely scoring or data-model
+logic** — new outcomes, scoring tweaks, override rules, config parsing,
+collection/pin logic, floor changes. All such logic is covered by the inline
+test harness and never touches Plex or the filesystem at runtime.
+
+Manual testing on Unraid is required when the change involves **Plex API
+semantics or real filesystem behaviour** that the inline stubs cannot
+faithfully replicate — path translation, `plex.history()` calls, rsync
+execution, file existence probes, parity detection, or any new plexapi
+call. For those, a representative test run against real data is the only
+meaningful gate.
+
 #### Run locally before pushing
 
+The host Python on macOS (and Unraid) does not have `pyyaml` or `plexapi`
+installed at system level. Running with bare `python3` fails with
+`Missing dependency`. Use a venv — the one-time setup is cheap:
+
 ```bash
-# 1. Compile check
+# One-time setup (reuse the venv across sessions)
+python3 -m venv /tmp/pmt-venv
+/tmp/pmt-venv/bin/pip install pyyaml plexapi -q
+
+# 1. Compile check (no deps needed — bare python3 is fine here)
 python3 -m py_compile tier.py
 
 # 2. YAML validity
-python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
+/tmp/pmt-venv/bin/python3 -c "import yaml; yaml.safe_load(open('example.tiering.yaml'))"
 
 # 3. Inline test harness
-python3 tier.py --_test
+/tmp/pmt-venv/bin/python3 tier.py --_test
 ```
 
 When adding non-trivial logic (scoring tweak, new outcome, path handling),
@@ -502,3 +524,70 @@ Renaming or removing an outcome breaks P2 when it lands. Don't.
    the README if user-facing behaviour or an outcome changed.
 6. Update the phase table in this file and in `tier.py`'s module
    docstring if the change closes out a phase.
+7. Follow the Standard PR flow below.
+
+## Standard PR flow
+
+Every code change ships as a PR off `main`. Follow these steps exactly —
+they are not boilerplate to be re-stated in each prompt.
+
+```bash
+# 1. Start from an up-to-date main
+git checkout main && git pull origin main
+
+# 2. Create the feature branch
+#    Convention: feat/<phase>-<slug>  |  fix/<slug>  |  docs/<slug>
+git checkout -b feat/p2.2-to-warm-moves
+
+# 3. Implement, then run the pre-commit check (see above)
+
+# 4. Stage and commit
+#    Single logical commit is fine for small PRs. Use imperative subject.
+git add tier.py example.tiering.yaml README.md AGENTS.md
+git commit -m "feat(P2.2): TO_WARM + RELOCATE_WARM move directions
+
+Brief body: what changed and why. One paragraph max.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+# 5. Push
+git push -u origin feat/p2.2-to-warm-moves
+
+# 6. Open the PR
+gh pr create \
+  --title "feat(P2.2): TO_WARM + RELOCATE_WARM move directions" \
+  --body "..."
+```
+
+### PR body structure
+
+Mirror the structure used in PRs #11, #13, #15, #16, #18:
+
+```markdown
+## Summary
+2-4 line elevator pitch.
+
+## Config schema (if applicable)
+YAML snippet of any new keys.
+
+## Behaviour
+Bullet list of what the feature does, edge cases, defaults.
+
+## Tests
+List of test names added; confirm all pass.
+
+## Docs
+What was updated in README, AGENTS.md, example.tiering.yaml.
+
+## Test plan
+Checkboxes for manual on-Unraid verification steps (only when the
+change touches Plex API semantics or real filesystem behaviour —
+see "When to trust CI vs require Unraid testing" above).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Check for an existing issue with `gh issue list` before opening the PR; if
+one exists add `Closes #N` to the body so it auto-closes on merge.
+
+**Do not merge.** Leave the PR open for human review.


### PR DESCRIPTION
## Summary

Moves repetitive boilerplate out of per-prompt specs and into the repo itself. Future prompts can drop 30+ lines of git/PR instructions and simply say "follow the Standard PR flow in AGENTS.md."

## Behaviour

Three additions to AGENTS.md:

- **Venv test command** — documents that bare `python3` fails on macOS/Unraid due to missing `pyyaml`/`plexapi`, and gives the correct `/tmp/pmt-venv` one-time-setup pattern. Prevents the repeated try-fail-retry loop seen in P2.1.
- **CI trust guidance** — explicit rule distinguishing scoring/data-model changes (CI sufficient to merge) from Plex API / filesystem changes (manual Unraid testing required). Stops over-specifying test plans for pure scoring PRs.
- **Standard PR flow** — canonical branch/commit/push/`gh pr create` steps plus PR body structure template, referencing existing PRs #11/#13/#15/#16/#18 as the style guide.

## Tests

Docs-only change — no code modified, no tests needed.

## Docs

AGENTS.md only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)