### PR TITLE
feat(P2.2/P2.3): TO_WARM + RELOCATE_WARM move directions with co-locate disk selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,9 @@ CLAUDE.md and GEMINI.md are symlinks to this file.
 | P0.5 | Disk eviction mode — mark warm-tier array disks as evicting; items on them get RELOCATE_WARM. Data model + reporting only; actual moves are P2 | Done |
 | P1   | Filesystem tier detection, path translation, majority-bytes rollup | Done |
 | P2.1 | Move executor — TO_HOT direction; rsync + size-verify + source delete; parity guard; dry-run by default | Done |
-| P2.2 | TO_WARM + RELOCATE_WARM moves | Pending |
-| P2.3 | Plex rescan automation post-move | Pending |
+| P2.2 | TO_WARM moves — demote from hot pool to chosen warm disk; co_locate_then_most_free destination selection | Done |
+| P2.3 | RELOCATE_WARM moves — drain evicting warm disks to healthy warm disks; source disk excluded from candidates | Done |
+| P2.4 | Plex rescan automation — dropped (Unraid user-share union makes it unnecessary for in-union moves) | N/A |
 | P3   | Hardening: lock file, currently-playing skip, free-space check, move cap | Pending |
 | P4   | Scheduled cron + size-triggered wrapper | Pending |
 
@@ -433,13 +434,21 @@ interrupted before the summary logged). Detecting `current_tier == HOT` on a
 TO_HOT item and logging SKIPPED instead of re-rsyncing is a cheap idempotency
 guard that prevents double-rsyncing. It does not indicate a scoring error.
 
-**`Item.warm_disk_files` — the ground truth for what gets moved.**
-`resolve_item_current_tier()` returns a 5-tuple; the fifth value is
+**`Item.warm_disk_files` and `Item.hot_pool_files` — the ground truth for what gets moved.**
+`resolve_item_current_tier()` returns a 6-tuple. The fifth value is
 `warm_disk_files: Dict[str, List[str]]` — a mapping of warm disk mount →
 list of resolved absolute file paths on that disk belonging to this item.
-This is what P2's rsync operates on directly via `--files-from`. Do not
-refactor to title-derived or directory-derived paths — the actual filesystem
-paths are the ground truth, not the Plex title or the common-ancestor dir.
+The sixth value is `hot_pool_files: List[str]` — the resolved absolute paths
+on the hot pool (populated whenever the item has HOT bytes). `_exec_single_move`
+operates on these via `--files-from` in all three move directions:
+
+- TO_HOT: source = `warm_disk_files`, dst = hot pool.
+- TO_WARM: source = `{hot_pool_mount: hot_pool_files}`, dst = chosen warm disk.
+- RELOCATE_WARM: source = `warm_disk_files` (all disks), dst = chosen warm disk.
+
+Do not refactor to title-derived or directory-derived paths — the actual
+filesystem paths are the ground truth, not the Plex title or the common-
+ancestor dir.
 
 The fourth value, `source_dirs: List[str]`, is derived from `warm_disk_files`
 for display in log lines only — it is the common-ancestor directory per warm
@@ -477,6 +486,46 @@ disk after a complete series move.
 Each disk in `warm_disk_files` is walked against its own root, not just
 `Item.current_disk` (the dominant disk), so multi-disk series are pruned
 correctly on every contributing disk.
+
+**Why warm destination selection co-locates series on one spindle.**
+`_select_warm_destination()` scores candidate disks by how many bytes of
+the item already live there. For a series move, the disk that already holds
+the most series bytes wins over the most-free disk. This is a correctness
+and UX property, not just a space optimisation: when a user binges a show,
+Unraid's parity-protected array wakes one spindle, not several scattered
+ones. A co-located series also simplifies future RELOCATE_WARM: one disk
+holds the whole item, so eviction is a single-source move. The annotation
+`(co-locate, +X GB existing)` in the log lets operators verify the
+heuristic is firing correctly.
+
+The series-vs-movie distinction matters: movies have no affinity — they
+always go to the most-free qualifying disk. Only series items (those where
+`item.media_type == "show"`) trigger the co-location path.
+
+**Why `current_disk` is excluded from RELOCATE_WARM candidates.**
+RELOCATE_WARM's purpose is to vacate an evicting disk. Selecting the same
+disk as the destination would either be a no-op (the file path doesn't
+change) or trigger an rsync from a disk to itself, which is undefined
+behaviour and almost certainly an error. `_select_warm_destination()` takes
+an optional `exclude_disk` parameter; `_run_move_pass` passes
+`item.current_disk` for RELOCATE_WARM items. The warm disk with the most
+existing series bytes is still preferred among the *remaining* candidates —
+the co-location logic is otherwise unchanged.
+
+**Why P2.4 (post-move Plex rescan) was scoped to TO_HOT only.**
+Unraid's user-share union filesystem presents `/mnt/user/<share>/` as a
+merged view that spans all array disks. TO_WARM and RELOCATE_WARM both
+move files between array disks, so the file's `/mnt/user/…` path is
+unchanged from Plex's perspective — no rescan is needed. TO_HOT moves a
+file from the array to a separate ZFS pool mount (e.g. `/mnt/hot_pool/`)
+that is outside the user-share union. Plex never sees a `/mnt/hot_pool/`
+path; instead, the mover relies on the user-share path remaining valid
+(it resolves through Unraid's union). If the hot pool is NOT mounted
+via user-share (i.e. `hot_pool_mount` is not under `user_share_prefix`),
+a rescan may be needed — the log line after a TO_HOT apply run recommends
+it. We do not automate the rescan because plexapi's `Library.update()` is
+a fire-and-forget with no completion signal, and the move executor must not
+block on Plex's indexing speed.
 
 ## Config shape
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,13 +338,87 @@ The eviction pass needs to attribute a series to exactly one disk. The
 chosen rule is **majority bytes**: whichever array disk holds the most
 bytes of the item wins and is stored as `Item.current_disk`. Consequences:
 
-- An item with only a small minority of bytes on an evicting disk does
-  **not** trigger `RELOCATE_WARM` — if 90% of a series is on disk1 and
-  10% on disk7, evicting disk7 does not justify moving the whole series.
-- `Item.current_disk` is only populated when `current_tier == "WARM"`.
-  HOT items don't get one — there is no per-disk concept on the ZFS pool.
+- An item with minority bytes on an evicting disk **does** trigger
+  `RELOCATE_WARM`, but only those minority files are moved. If 90% of a
+  series is on disk1 and 10% on disk7, evicting disk7 sets
+  `relocate_source_override = {disk7: [minority files]}` and overrides
+  `current_disk` to disk7. `_select_warm_destination` then excludes disk7
+  and co-locates with disk1 (the majority disk already in `warm_disk_files`).
+  Only the 10% moves; the 90% on disk1 is untouched.
+- `Item.current_disk` is set to the majority warm disk for `current_tier ==
+  "WARM"` items, and overridden to the evicting disk for minority-evict items
+  during the eviction pass. It is `None` for HOT-majority and UNKNOWN items.
 - Do not refactor to "first disk found" or a list of all disks containing
   the item. The majority-bytes winner is intentional.
+
+### HOT-majority items populate `warm_disk_files` for stragglers
+
+`resolve_item_current_tier()` always returns `warm_disk_files` even when
+`split["HOT"] > 0.5`. Early versions returned an empty dict for HOT-majority
+items, which silently broke two downstream features:
+
+1. **Straggler promotion** (`collect_all` post-scoring): `STAY_HOT +
+   warm_disk_files → TO_HOT` could never fire because `warm_disk_files` was
+   always `{}` for HOT items. A show like Chicago Med with most seasons on the
+   hot pool but a few seasons still on warm disks would report `STAY_HOT`
+   forever instead of finishing the migration.
+
+2. **Minority-evict detection**: the eviction pass scans `warm_disk_files` for
+   files on evicting disks. With an empty dict, HOT-majority items with warm
+   stragglers on an evicting disk were invisible to the eviction pass.
+
+Fix: return `warm_source_dirs` and `dict(disk_files)` for the HOT-majority
+branch. `current_disk` stays `None` (the item's primary residence is HOT, not
+a warm spindle). The straggler pass and eviction pass read `warm_disk_files`
+to find minority warm files.
+
+### Straggler promotion: STAY_HOT and PIN_HOT with warm stragglers → TO_HOT
+
+`collect_all`'s straggler pass (after scoring and eviction) converts:
+
+- `STAY_HOT + non-empty warm_disk_files` → `TO_HOT`: majority bytes are on the
+  hot pool but some files remain on warm disks (typical: a prior move was
+  interrupted after rsync but before source-delete, leaving orphaned seasons).
+- `PIN_HOT + non-empty warm_disk_files` → `TO_HOT`: item is library- or
+  title-pinned to HOT but physically still lives on a warm disk. The pin cannot
+  take effect until the file is actually on the hot pool. Converting to TO_HOT
+  lets P2 promote it; the next run shows `PIN_HOT` once promotion is complete.
+
+Neither conversion demotes anything. `warm_disk_files` being non-empty is the
+sole trigger — if it is empty (item genuinely already on HOT), no change.
+
+### Minority-evict: `Item.relocate_source_override`
+
+When the eviction pass detects that an item has files on an evicting disk but
+`current_disk` (majority bytes) is a *safe* disk, it:
+
+1. Sets `item.relocate_source_override = {evicting_disk: [minority files]}`
+   so `_exec_single_move` rsyncs only those files, not the whole `warm_disk_files`.
+2. Overrides `item.current_disk` to the evicting disk so `_select_warm_destination`
+   uses it as `exclude_disk`, which keeps the evicting disk out of candidates.
+3. Leaves `warm_disk_files` intact so co-location scoring can see the safe
+   majority disk and prefer it as the destination.
+
+Result: only the evicting-disk files move; the majority files on the safe disk
+are untouched; co-location naturally consolidates everything on one spindle.
+
+`relocate_source_override` is `None` for majority-evict items (the original
+case) and for all non-eviction moves. `None` means "use full `warm_disk_files`."
+
+### Article normalization in `_is_movie_per_folder`
+
+Plex's sort-title convention moves leading articles to the end:
+`The Bounty Hunter (2010)` folder → `Bounty Hunter, The (2010).mkv` file.
+
+`_is_movie_per_folder(parent_name, stem)` normalises both names to a canonical
+"natural order" form before comparing, using `_SORT_TITLE_RE` to detect and
+invert the sort-title article form. This prevents movie-per-folder companion
+detection from being bypassed when a library is organised with natural-order
+folder names but Plex-renamed sort-title filenames (or vice versa).
+
+The cross-tier companion probe (scanning the hot pool for stranded extras after
+a partial move) also uses `_is_movie_per_folder`, so article-inversion titles
+are handled there too.
 
 ### Graceful degradation
 
@@ -444,7 +518,8 @@ operates on these via `--files-from` in all three move directions:
 
 - TO_HOT: source = `warm_disk_files`, dst = hot pool.
 - TO_WARM: source = `{hot_pool_mount: hot_pool_files}`, dst = chosen warm disk.
-- RELOCATE_WARM: source = `warm_disk_files` (all disks), dst = chosen warm disk.
+- RELOCATE_WARM: source = `relocate_source_override` when set (minority-evict),
+  else `warm_disk_files` (all warm disks), dst = chosen warm disk.
 
 Do not refactor to title-derived or directory-derived paths — the actual
 filesystem paths are the ground truth, not the Plex title or the common-
@@ -573,13 +648,13 @@ state.json` — the volume is persistent and already mounted. The one
 exception is the move executor, which writes to the hot pool destination;
 that path is a separate read-write mount.
 
-### `--apply` is now live in P2.1 (TO_HOT only)
+### `--apply` covers all three move directions (P2.1–P2.3)
 
-`--apply` executes TO_HOT moves when `moves.enabled: true`. Adding
-support for new move directions (TO_WARM, RELOCATE_WARM) requires a
-corresponding phase bump to P2.2. The full P3 safety guards (currently-
-playing skip, free-space check, move-size cap, lock file) are still
-pending — don't add them piecemeal without the full P3 spec.
+`--apply` executes TO_HOT, TO_WARM, and RELOCATE_WARM moves when
+`moves.enabled: true`. All three directions are serialised in a single
+pass. The full P3 safety guards (currently-playing skip, free-space check,
+move-size cap, lock file) are still pending — don't add them piecemeal
+without the full P3 spec.
 
 ### Notifiers must not raise
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,11 +469,29 @@ etc.). Sidecar files (`.srt`, `.nfo`, `.sub`, language-tagged variants like
 by scanning the media file's directory for files whose stem matches. If they
 are left on the warm disk after the media file moves, Plex cannot find them.
 
-`_find_companion_files(media_path)` scans the media file's parent directory
-for any file whose stem equals the media stem or starts with `stem + "."`.
-Results are appended to `warm_disk_files[disk]` so rsync picks them up.
-Do not replace this with an API-based approach — the API does not expose
-sidecar files.
+`_find_companion_files(media_path)` operates in two modes based on folder
+structure:
+
+**Movie-per-folder** (parent directory name == media file stem, e.g.
+`.../Austin Powers in Goldmember (2002)/Austin Powers in Goldmember (2002).mkv`):
+ALL other files in the directory are returned. Plex extras — trailers,
+featurettes, deleted scenes, behind-the-scenes, music videos — are stored here
+using Plex's suffix conventions (`-trailer.mkv`, `-featurette.mkv`, etc.) and
+have completely different stems from the main title file. Stem-only matching
+would silently leave every extra behind on the source disk.
+
+**Shared folder** (year folder, library root, or any other parent not named
+after the movie — parent name ≠ file stem): only files whose stem equals the
+media stem or starts with `stem + "."` are returned. This is the subtitle/NFO
+companion case for year-organised libraries (e.g. `.../2002/Movie.mkv`) where
+multiple movies share one folder and returning all files would move unrelated
+movies' files.
+
+Detection is a case-insensitive exact match between parent directory name and
+media file stem. Year folders (`2002`) and library roots (`Movies`) never match
+a movie stem. Do not replace this with an API-based approach — Plex's extras
+API (`movie.extras()`) requires one extra network call per movie and is not
+needed when the filesystem structure already encodes the information.
 
 **Why empty ancestor directories are pruned after source delete.**
 After `os.unlink` on each source file, `_run_move_pass` walks every ancestor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,23 +387,39 @@ to find minority warm files.
 Neither conversion demotes anything. `warm_disk_files` being non-empty is the
 sole trigger — if it is empty (item genuinely already on HOT), no change.
 
-### Minority-evict: `Item.relocate_source_override`
+### `Item.relocate_source_override` — evicting-disk files only
 
-When the eviction pass detects that an item has files on an evicting disk but
-`current_disk` (majority bytes) is a *safe* disk, it:
+`relocate_source_override` is set by the eviction pass for **all** RELOCATE_WARM
+items (both majority-evict and minority-evict). It restricts the rsync source and
+the subsequent delete to only the files that live on the evicting disk.
 
-1. Sets `item.relocate_source_override = {evicting_disk: [minority files]}`
-   so `_exec_single_move` rsyncs only those files, not the whole `warm_disk_files`.
-2. Overrides `item.current_disk` to the evicting disk so `_select_warm_destination`
-   uses it as `exclude_disk`, which keeps the evicting disk out of candidates.
-3. Leaves `warm_disk_files` intact so co-location scoring can see the safe
-   majority disk and prefer it as the destination.
+**Why this is required even for majority-evict items (data-loss guard).**
+`warm_disk_files` contains files from *all* warm disks an item spans. For a
+series majority on disk7 with minority seasons also on disk3, and disk7 being
+evicted: without `relocate_source_override`, the eviction move would:
 
-Result: only the evicting-disk files move; the majority files on the safe disk
-are untouched; co-location naturally consolidates everything on one spindle.
+1. Rsync from all warm sources (disk7 + disk3) to the destination (co-location
+   picks disk3, the safe majority-bytes disk).
+2. Size-verify passes — the disk3 files are already at the destination (they
+   never moved; rsync was a no-op for them).
+3. Delete runs against the full `warm_disk_files`, including disk3 — wiping
+   those files permanently.
 
-`relocate_source_override` is `None` for majority-evict items (the original
-case) and for all non-eviction moves. `None` means "use full `warm_disk_files`."
+Fix: always set `relocate_source_override = {evicting_disk: files_on_that_disk}`
+so the delete is bounded to exactly the files that were actually transferred.
+
+**Minority-evict additional step.** When `current_disk` (majority bytes) is a
+*safe* disk, the pass also overrides `item.current_disk` to the evicting disk so
+`_select_warm_destination` uses it as `exclude_disk`. This keeps the evicting
+disk out of destination candidates. `warm_disk_files` is left intact so
+co-location scoring can see the safe majority disk and prefer it as the
+destination.
+
+Result for all cases: only the evicting-disk files are rsynced and deleted;
+files on safe disks are untouched; co-location consolidates on one spindle.
+
+`relocate_source_override` is `None` for non-eviction moves. `None` means
+"use full `warm_disk_files`."
 
 ### Article normalization in `_is_movie_per_folder`
 
@@ -518,8 +534,8 @@ operates on these via `--files-from` in all three move directions:
 
 - TO_HOT: source = `warm_disk_files`, dst = hot pool.
 - TO_WARM: source = `{hot_pool_mount: hot_pool_files}`, dst = chosen warm disk.
-- RELOCATE_WARM: source = `relocate_source_override` when set (minority-evict),
-  else `warm_disk_files` (all warm disks), dst = chosen warm disk.
+- RELOCATE_WARM: source = `relocate_source_override` (always set by the eviction
+  pass — evicting-disk files only), dst = chosen warm disk.
 
 Do not refactor to title-derived or directory-derived paths — the actual
 filesystem paths are the ground truth, not the Plex title or the common-

--- a/README.md
+++ b/README.md
@@ -616,11 +616,38 @@ moves:
   apply: true   # execute moves without --apply on the CLI
 ```
 
-### Scope (P2.1)
+### Scope
 
-Only `TO_HOT` items are moved in P2.1. Items with outcome `TO_WARM`,
-`RELOCATE_WARM`, `SHOULD_BE_HOT`, or `SHOULD_BE_WARM` are tallied in a single
-skip line and left for P2.2/P2.3.
+All three move directions are active:
+
+| Direction | Source | Destination | Trigger |
+| --- | --- | --- | --- |
+| `TO_HOT` | Warm array disk | Hot pool | Score above `score_to_hot`, recency floor, or pin |
+| `TO_WARM` | Hot pool | Warm array disk | Score drops below `score_to_warm` |
+| `RELOCATE_WARM` | Evicting warm disk | Healthy warm disk | Item on a disk listed in `array_disk_evict.disks` |
+
+Items with outcome `SHOULD_BE_HOT` or `SHOULD_BE_WARM` (tier detection
+inactive) are reported but not moved.
+
+**Warm disk selection** (`TO_WARM` and `RELOCATE_WARM`): tier.py picks the
+destination warm disk using the `co_locate_then_most_free` strategy:
+
+1. Exclude the source disk (RELOCATE_WARM) or no exclusion (TO_WARM).
+2. Filter candidates by free space ≥ item size + `safety_margin_gb`.
+3. Among qualified disks, prefer the one that already holds the most bytes of
+   this item (co-location — keeps a series on one spindle for efficient binging).
+4. Fallback: most-free disk.
+
+**Minority-evict handling**: if a series has its majority bytes on a safe disk
+but a season or two on an evicting disk, only those evicting-disk files are
+moved. The majority files on the safe disk are untouched and the move
+co-locates with the safe disk automatically.
+
+**Straggler cleanup**: after scoring, items that are majority-on-HOT but still
+have files on warm disks (`STAY_HOT + warm stragglers`) are automatically
+promoted to `TO_HOT` to finish the migration. Similarly, items pinned to HOT
+(`PIN_HOT`) that physically live on a warm disk are converted to `TO_HOT` so
+the pin takes effect.
 
 ### Source deletion
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ watch history and age, and recommends whether each item should sit on the HOT
 tier (HDD ZFS pool) or the WARM tier (Unraid parity array). Scheduled to run
 monthly or when the ZFS pool fills past a threshold.
 
-**Current status: Phase P2.1 — TO_HOT moves.** The script connects to Plex,
-computes scores, detects the current tier of each item, and (when
-`moves.enabled: true`) dry-runs or executes rsync moves from the Unraid parity
-array to the hot ZFS pool. Pass `--apply` to execute; default is dry-run.
+**Current status: Phase P2.2 + P2.3 — all three move directions.** The script
+connects to Plex, computes scores, detects the current tier of each item, and
+(when `moves.enabled: true`) dry-runs or executes rsync moves in all three
+directions: TO_HOT (warm array → hot pool), TO_WARM (hot pool → warm array),
+and RELOCATE_WARM (evicting warm disk → healthy warm disk). Pass `--apply` to
+execute; default is dry-run.
 
 ## Phase roadmap
 
@@ -22,8 +24,9 @@ array to the hot ZFS pool. Pass `--apply` to execute; default is dry-run.
 | P0.5 | Disk eviction — mark warm-tier array disks as evicting; items on them get `RELOCATE_WARM`. Data model + reporting only; actual moves are P2. | **Done** |
 | P1 | Filesystem probing to detect current tier. Auto-detect array disks + Plex path translation. Majority-bytes rollup. | **Done** |
 | P2.1 | Move executor — TO_HOT direction. rsync from warm array to hot pool. Dry-run by default; `--apply` executes. | **Done** |
-| P2.2 | TO_WARM + RELOCATE_WARM moves. | Pending |
-| P2.3 | Plex rescan automation post-move. | Pending |
+| P2.2 | TO_WARM moves — demote items from hot pool to chosen warm disk (co-location + most-free selection). | **Done** |
+| P2.3 | RELOCATE_WARM moves — drain evicting warm disks to healthy warm disks. Evicting disk excluded from candidates. | **Done** |
+| P2.4 | Plex rescan automation — **intentionally not implemented**. Unraid's user-share union means Plex always reads through `/mnt/user/` regardless of which physical disk backs a file; TO_WARM and RELOCATE_WARM moves are invisible to Plex at the path level. Only TO_HOT (which moves files off the union to a separate ZFS mount) recommends a rescan. | N/A |
 | P3 | Hardened safeguards (lock file, currently-playing skip, free-space check, move-size cap). | Pending |
 | P4 | Scheduled cron + size-triggered wrapper. | Pending |
 

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -206,6 +206,12 @@ moves:
   # moves to run in the background without saturating the array.
   bandwidth_limit_mbps: null
   # - 50    # example: cap at 50 MB/s
+  # Throughput estimates used for the ETA shown at the start of each run.
+  # TO_HOT writes to the ZFS/NVMe hot pool (typically fast).
+  # TO_WARM and RELOCATE_WARM write to spinning-disk array (typically slower).
+  # Adjust to reflect your actual hardware if the ETA is consistently off.
+  estimated_hot_mbps: 200
+  estimated_warm_mbps: 50
   # Destination warm-disk selection for TO_WARM and RELOCATE_WARM moves.
   warm_disk_selection:
     # Only strategy in v1. For each item needing a warm destination:

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -206,6 +206,19 @@ moves:
   # moves to run in the background without saturating the array.
   bandwidth_limit_mbps: null
   # - 50    # example: cap at 50 MB/s
+  # Destination warm-disk selection for TO_WARM and RELOCATE_WARM moves.
+  warm_disk_selection:
+    # Only strategy in v1. For each item needing a warm destination:
+    #   1. Filter disks by free space >= item size + safety_margin_gb.
+    #   2. For series: prefer the disk that already holds the most bytes
+    #      of that series (co-location keeps a show on one spindle).
+    #   3. Fallback: most free space wins.
+    # Items with no qualifying disk are skipped with [FAILED] in the log.
+    strategy: "co_locate_then_most_free"
+    # Minimum free space to leave on the target disk after the move (GB).
+    # Conservative: a fully accurate check would subtract existing series
+    # bytes already on the target, but the simple upper-bound is safer.
+    safety_margin_gb: 50
 
 # Capacity — not used in P0, wired up in P3.
 # Budget-aware promotion/demotion keeps the hot ZFS pool under the ceiling.

--- a/tier.py
+++ b/tier.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-tier.py — Unraid media tiering script (Phase P2.1)
+tier.py — Unraid media tiering script (Phase P2.2 + P2.3)
 
 Pulls watch history and metadata from Plex, computes a heat score per
 media item (movies + TV series), probes the filesystem to determine
 where each item currently lives, and recommends where it should live —
 HOT (fast pool) or WARM (Unraid array). With --apply and moves.enabled,
-executes TO_HOT rsync moves serially.
+executes TO_HOT, TO_WARM, and RELOCATE_WARM rsync moves serially.
 
 Phase status:
   P0  (done)        Read-only analysis from Plex catalog + watch history.
@@ -26,12 +26,22 @@ Phase status:
   P1  (done)        Filesystem probing to detect current tier. Auto-
                     detects array disks, translates Plex-side paths via
                     plex_path_map, rolls multi-part items up by bytes.
-  P2.1 (this file)  Move executor — TO_HOT direction. rsync from warm
+  P2.1 (done)       Move executor — TO_HOT direction. rsync from warm
                     array disk to hot ZFS pool. Dry-run by default;
                     --apply executes. Source deleted after size-verify
                     when delete_source_after_verify=true.
-  P2.2 (later)      TO_WARM + RELOCATE_WARM moves.
-  P2.3 (later)      Plex rescan automation.
+  P2.2 (done)       TO_WARM moves — demote from hot ZFS pool to chosen
+                    warm array disk. Destination selected via
+                    co_locate_then_most_free strategy with safety margin.
+  P2.3 (done)       RELOCATE_WARM moves — move items on evicting warm
+                    disks to a healthy warm disk. Same rsync+verify+
+                    delete flow; source (evicting) disk excluded from
+                    destination candidates.
+  P2.4 (dropped)    Plex rescan automation — unnecessary under Unraid's
+                    user-share union: TO_WARM and RELOCATE_WARM keep
+                    files within /mnt/user/; Plex path references remain
+                    valid without a rescan. Only TO_HOT (which moves
+                    files outside the union) recommends a rescan.
   P3  (later)       Hardened safeguards (lock file, currently-playing skip,
                     free-space check, max-move cap).
   P4  (later)       Scheduled cron + size-triggered wrapper.
@@ -59,6 +69,7 @@ import logging.handlers
 import math
 import os
 import re
+import shutil
 import subprocess
 import sys
 import traceback
@@ -175,6 +186,15 @@ DEFAULT_CONFIG = {
         "size_verify": True,
         "parity_check_blocking": True,
         "bandwidth_limit_mbps": None,
+        "warm_disk_selection": {
+            # How to pick the destination warm disk for TO_WARM / RELOCATE_WARM.
+            # Only strategy in v1: prefer the disk that already holds the most
+            # bytes of this series (co-location), falling back to most-free.
+            "strategy": "co_locate_then_most_free",
+            # Leave at least this many GB free on the target disk after the move.
+            # Items that would exceed this margin are skipped with [FAILED].
+            "safety_margin_gb": 50,
+        },
     },
     "logging": {
         "path": "/config/tier.log",  # container-friendly default
@@ -382,6 +402,10 @@ class Item:
     # of how the library is organised on disk (per-item folders vs shared
     # year folders). Dominant disk is at key == current_disk.
     warm_disk_files: Dict[str, List[str]] = field(default_factory=dict)
+    # Resolved absolute paths of files currently on the hot pool — populated
+    # only when current_tier is HOT (or MIXED with hot bytes). Used by the
+    # TO_WARM move executor as the rsync source list.
+    hot_pool_files: List[str] = field(default_factory=list)
     # Common-ancestor source dirs (dominant disk first) — kept for display /
     # log output only.  NOT used for rsync source paths.
     source_dirs: List[str] = field(default_factory=list)
@@ -713,17 +737,18 @@ def resolve_item_current_tier(
     hot_mount: str,
     array_disks: List[str],
     user_share_prefix: str = "",
-) -> Tuple[str, dict, Optional[str], List[str], Dict[str, List[str]]]:
+) -> Tuple[str, dict, Optional[str], List[str], Dict[str, List[str]], List[str]]:
     """Majority-bytes rollup of tier for a multi-part item.
 
     parts: iterable of (plex_file_path, size_bytes).
     Returns:
-      (tier_str, breakdown, dominant_warm_disk, source_dirs, warm_disk_files)
+      (tier_str, breakdown, dominant_warm_disk, source_dirs, warm_disk_files, hot_pool_files)
       tier_str: 'HOT' | 'WARM' | 'MIXED' | 'UNKNOWN'
       breakdown: dict of per-tier byte shares (0.0..1.0)
       dominant_warm_disk: path of the WARM disk with most bytes, or None
       source_dirs: common-ancestor dirs per warm disk (dominant first) — display only
       warm_disk_files: {disk: [resolved file paths]} for all warm disks
+      hot_pool_files: resolved file paths on the hot pool (for TO_WARM rsync source)
 
     Decision rules:
       - Majority (>50%) bytes on HOT  -> HOT
@@ -734,6 +759,7 @@ def resolve_item_current_tier(
     totals = {"HOT": 0, "WARM": 0, "UNKNOWN": 0}
     disk_bytes: dict = {}  # warm disk path -> bytes on that disk
     disk_files: Dict[str, List[str]] = {}  # warm disk path -> list of resolved file paths
+    hot_files: List[str] = []              # files resolved to the hot pool
     total = 0
     for plex_path, size in parts:
         if not size or size <= 0:
@@ -743,21 +769,38 @@ def resolve_item_current_tier(
         resolved = resolve_user_share(translated, user_share_prefix, hot_mount, array_disks)
         tier = classify_path(resolved, hot_mount, array_disks)
         totals[tier] += size
-        if tier == "WARM":
+        if tier == "HOT":
+            hot_files.append(resolved)
+        elif tier == "WARM":
             for disk in array_disks or []:
                 d = disk.rstrip("/")
                 if resolved == d or resolved.startswith(d + "/"):
                     disk_bytes[disk] = disk_bytes.get(disk, 0) + size
                     disk_files.setdefault(disk, []).append(resolved)
                     break
-    # Augment each disk's file list with companion files (subtitles, NFO, etc.)
-    # that share the media file's stem. Plex discovers external subtitles this
-    # way at play time, so they must live alongside the media on the same tier.
+
+    # Augment file lists with companion files (subtitles, NFO, etc.) that
+    # share the media file's stem. A single shared `seen` set prevents the
+    # same companion from appearing in both hot_files and a warm disk list.
     seen: set = set()
+
+    # Hot pool companions
+    for mf in hot_files:
+        seen.add(mf)
+    hot_extras: List[str] = []
+    for mf in hot_files:
+        for companion in _find_companion_files(mf):
+            if companion not in seen:
+                seen.add(companion)
+                hot_extras.append(companion)
+    hot_files.extend(hot_extras)
+
+    # Warm disk companions
     for disk in list(disk_files.keys()):
         extras: List[str] = []
         for mf in disk_files[disk]:
             seen.add(mf)
+        for mf in disk_files[disk]:
             for companion in _find_companion_files(mf):
                 if companion not in seen:
                     seen.add(companion)
@@ -777,15 +820,15 @@ def resolve_item_current_tier(
         else:
             warm_source_dirs.append(src)
     if total == 0:
-        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, [], {}
+        return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, [], {}, []
     split = {k: round(v / total, 4) for k, v in totals.items()}
     if split["HOT"] > 0.5:
-        return "HOT", split, None, [], {}
+        return "HOT", split, None, [], {}, hot_files
     if split["WARM"] > 0.5:
-        return "WARM", split, dominant, warm_source_dirs, dict(disk_files)
+        return "WARM", split, dominant, warm_source_dirs, dict(disk_files), hot_files
     if split["UNKNOWN"] > 0.5:
-        return "UNKNOWN", split, None, [], {}
-    return "MIXED", split, dominant, warm_source_dirs, dict(disk_files)
+        return "UNKNOWN", split, None, [], {}, hot_files
+    return "MIXED", split, dominant, warm_source_dirs, dict(disk_files), hot_files
 
 
 def _media_parts(media_list) -> Iterable[Tuple[str, int]]:
@@ -1365,11 +1408,13 @@ def collect_movies(
         current_disk: Optional[str] = None
         source_dirs: List[str] = []
         tier_split: Optional[dict] = None
+        warm_disk_files: Dict[str, List[str]] = {}
+        hot_pool_files: List[str] = []
         if tier_probing:
             parts = []
             for m in group:
                 parts.extend(_media_parts(getattr(m, "media", None)))
-            current_tier, tier_split, current_disk, source_dirs, warm_disk_files = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs, warm_disk_files, hot_pool_files = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1394,6 +1439,7 @@ def collect_movies(
             current_disk=current_disk,
             source_dirs=source_dirs,
             warm_disk_files=warm_disk_files,
+            hot_pool_files=hot_pool_files,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=primary_rk,
             recently_added=recently_added,
@@ -1476,11 +1522,13 @@ def collect_series(
         current_disk: Optional[str] = None
         source_dirs: List[str] = []
         tier_split: Optional[dict] = None
+        warm_disk_files: Dict[str, List[str]] = {}
+        hot_pool_files: List[str] = []
         if tier_probing:
             parts = []
             for ep in episodes:
                 parts.extend(_media_parts(getattr(ep, "media", None)))
-            current_tier, tier_split, current_disk, source_dirs, warm_disk_files = resolve_item_current_tier(
+            current_tier, tier_split, current_disk, source_dirs, warm_disk_files, hot_pool_files = resolve_item_current_tier(
                 parts, path_map, hot_mount, array_disks, user_share_prefix,
             )
             if tier_split:
@@ -1500,6 +1548,7 @@ def collect_series(
             current_disk=current_disk,
             source_dirs=source_dirs,
             warm_disk_files=warm_disk_files,
+            hot_pool_files=hot_pool_files,
             outcome="NEUTRAL",  # finalised in post-scoring override pass
             rating_key=rk,
             recently_added=recently_added,
@@ -1797,6 +1846,194 @@ def _fmt_eta(seconds: float) -> str:
 _ASSUMED_THROUGHPUT_BPS = 200 * 1024 * 1024  # 200 MB/s
 
 
+def _disk_free_bytes(path: str) -> int:
+    """Return free bytes on the filesystem at path, or 0 on error."""
+    try:
+        return shutil.disk_usage(path).free
+    except OSError:
+        return 0
+
+
+def _select_warm_destination(
+    item: "Item",
+    array_disks: List[str],
+    safety_margin_bytes: int,
+    exclude_disk: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Choose a warm disk for TO_WARM or RELOCATE_WARM moves.
+
+    Returns (chosen_disk, annotation) where annotation describes why the disk
+    was chosen ("most-free" | "co-locate, +X GB existing"), or (None, reason)
+    when no qualifying disk exists.
+
+    Selection rules:
+      1. Exclude exclude_disk (used for RELOCATE_WARM to avoid the source disk).
+      2. Filter by capacity: free >= item.size_bytes + safety_margin_bytes.
+      3. Co-location: for series, prefer the candidate disk that already holds
+         the most bytes of this item (from warm_disk_files). Keeps a series on
+         one spindle so a binge only wakes one drive.
+      4. Fallback: most free space.
+    """
+    candidates = [d for d in array_disks if d != exclude_disk]
+    if not candidates:
+        return None, "no candidate warm disks"
+
+    needed = item.size_bytes + safety_margin_bytes
+    qualified = [d for d in candidates if _disk_free_bytes(d) >= needed]
+    if not qualified:
+        return None, f"no disk with ≥ {_fmt_size(needed / (1024 ** 3))} free (safety_margin included)"
+
+    # Co-location: prefer the qualified disk that already holds the most bytes
+    # of this series. Only applicable to series with warm_disk_files populated
+    # (i.e. the item has some bytes already on at least one warm disk).
+    if item.kind == "series" and item.warm_disk_files:
+        best_disk: Optional[str] = None
+        best_sz = 0
+        for disk in qualified:
+            if disk not in item.warm_disk_files:
+                continue
+            sz = sum(
+                os.path.getsize(f)
+                for f in item.warm_disk_files[disk]
+                if os.path.exists(f)
+            )
+            if sz > best_sz:
+                best_sz = sz
+                best_disk = disk
+        if best_disk:
+            return best_disk, f"co-locate, +{_fmt_size(best_sz / (1024 ** 3))} existing"
+
+    best = max(qualified, key=_disk_free_bytes)
+    return best, "most-free"
+
+
+def _exec_single_move(
+    prefix: str,
+    title_year: str,
+    files_by_src_root: Dict[str, List[str]],
+    dst_root: str,
+    rsync_opts: List[str],
+    size_verify: bool,
+    delete_after: bool,
+) -> str:
+    """Execute rsync, optional size verify, and optional source delete for one item.
+
+    files_by_src_root: {src_root: [absolute file paths]} — each src_root is
+        rsynced to dst_root preserving the relative path structure.
+    dst_root: absolute destination root (e.g. hot pool mount or warm disk mount).
+
+    Returns "ok" | "failed" | "delete_partial".
+    """
+    import tempfile as _tempfile
+
+    dst = dst_root.rstrip("/")
+
+    for src_root, files in files_by_src_root.items():
+        src_r = src_root.rstrip("/") + "/"
+        rel_paths = [
+            f[len(src_r):] if f.startswith(src_r) else f.lstrip("/")
+            for f in files
+        ]
+        try:
+            with _tempfile.NamedTemporaryFile(
+                mode="w", suffix=".txt", delete=False, prefix="tier_rsync_"
+            ) as flist:
+                flist.write("\n".join(rel_paths))
+                flist_path = flist.name
+        except OSError as exc:
+            log.error("%s [FAILED] %s — cannot write files-from list: %s",
+                      prefix, title_year, exc)
+            return "failed"
+
+        rsync_ok = True
+        try:
+            cmd = (["rsync"] + rsync_opts
+                   + [f"--files-from={flist_path}", src_r, dst + "/"])
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except OSError as exc:
+            log.error("%s [FAILED] %s — rsync failed to start: %s",
+                      prefix, title_year, exc)
+            rsync_ok = False
+        finally:
+            try:
+                os.unlink(flist_path)
+            except OSError:
+                pass
+
+        if not rsync_ok:
+            return "failed"
+        if result.returncode != 0:
+            stderr_lines = (result.stderr or "").strip().splitlines()[:5]
+            stderr_str = "; ".join(stderr_lines) if stderr_lines else ""
+            log.error(
+                "%s [FAILED] %s — rsync exit %d (src=%s)%s — source unchanged",
+                prefix, title_year, result.returncode, src_root,
+                f": {stderr_str}" if stderr_str else "",
+            )
+            return "failed"
+
+    # Size verification: sum source vs destination byte counts file-by-file.
+    # File-level measurement is immune to concurrent downloads to the same dir.
+    if size_verify:
+        try:
+            src_sz = dst_sz = 0
+            for src_root, files in files_by_src_root.items():
+                src_r = src_root.rstrip("/")
+                for f in files:
+                    src_sz += os.path.getsize(f)
+                    dst_f = dst + f[len(src_r):]
+                    if os.path.exists(dst_f):
+                        dst_sz += os.path.getsize(dst_f)
+            if abs(src_sz - dst_sz) > 1024:
+                log.error(
+                    "%s [FAILED] %s — size verify failed (src=%d dst=%d) — source unchanged",
+                    prefix, title_year, src_sz, dst_sz,
+                )
+                return "failed"
+        except Exception as exc:  # noqa: BLE001
+            log.error(
+                "%s [FAILED] %s — size verify error: %s — source unchanged",
+                prefix, title_year, exc,
+            )
+            return "failed"
+
+    # Delete source files and prune empty ancestor directories.
+    if delete_after:
+        delete_failed = False
+        disk_leaf_dirs: Dict[str, set] = {}
+        for src_root, files in files_by_src_root.items():
+            disk_leaf_dirs[src_root] = set()
+            for f in files:
+                try:
+                    os.unlink(f)
+                    disk_leaf_dirs[src_root].add(os.path.dirname(f))
+                except OSError as exc:
+                    log.warning(
+                        "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
+                        prefix, title_year, f, exc,
+                    )
+                    delete_failed = True
+
+        all_dirs: set = set()
+        for src_root, leaf_dirs in disk_leaf_dirs.items():
+            disk_root = src_root.rstrip("/")
+            for d in leaf_dirs:
+                current = d
+                while current and current != disk_root and current.startswith(disk_root + "/"):
+                    all_dirs.add(current)
+                    current = os.path.dirname(current)
+        for d in sorted(all_dirs, reverse=True):
+            try:
+                os.rmdir(d)
+            except OSError:
+                pass
+
+        if delete_failed:
+            return "delete_partial"
+
+    return "ok"
+
+
 def _compute_destination_path(item: "Item", hot_pool_mount: str) -> Optional[str]:
     """Return the hot-pool path for a TO_HOT move.
 
@@ -1839,7 +2076,7 @@ def _check_parity_in_progress() -> bool:
 
 
 def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
-    """Dry-run or execute the TO_HOT move pass.
+    """Dry-run or execute moves for TO_HOT, TO_WARM, and RELOCATE_WARM outcomes.
 
     When apply=False: emits [DRY-RUN] log lines for every projected move.
     When apply=True:  executes rsync serially, verifies sizes, optionally
@@ -1856,61 +2093,142 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         log.warning("Moves: moves.enabled=true but paths.hot_pool_mount not set — skipping")
         return
 
-    # Tally outcomes not yet supported so we can emit a single skip line.
+    array_disks = resolve_array_disks(cfg)
+
+    warm_sel_cfg = (moves_cfg.get("warm_disk_selection") or {})
+    safety_margin_bytes = int(float(warm_sel_cfg.get("safety_margin_gb") or 50) * 1024 ** 3)
+
+    # Tally SHOULD_BE_* outcomes (tier unknown — nothing to move).
     skip_outcomes: dict = {}
     for it in items:
-        if it.outcome in ("TO_WARM", "RELOCATE_WARM", "SHOULD_BE_HOT", "SHOULD_BE_WARM"):
+        if it.outcome in ("SHOULD_BE_HOT", "SHOULD_BE_WARM"):
             skip_outcomes[it.outcome] = skip_outcomes.get(it.outcome, 0) + 1
     if skip_outcomes:
         parts_str = "  ".join(f"{k}={v}" for k, v in sorted(skip_outcomes.items()))
         log.info(
-            "Moves: skipping %d items in directions not yet supported (%s)",
+            "Moves: skipping %d items with unknown current tier (%s)",
             sum(skip_outcomes.values()), parts_str,
         )
 
-    # Separate already-HOT items (idempotency) from actionable TO_HOT items.
+    # --- Build per-direction queues ---
+
+    # TO_HOT: already-HOT items are idempotency skips; others need warm_disk_files.
     to_hot_skip = [it for it in items if it.outcome == "TO_HOT" and it.current_tier == "HOT"]
-    to_hot_move = [it for it in items if it.outcome == "TO_HOT" and it.current_tier != "HOT"]
-
-    # Validate each candidate has file-level data we need for rsync.
-    moves: List["Item"] = []
-    for it in to_hot_move:
-        if not it.warm_disk_files:
-            log.warning(
-                "Moves: [SKIP] %s — no warm_disk_files (tier detection inactive?)",
-                it.title_year,
-            )
+    to_hot_move: List["Item"] = []
+    for it in items:
+        if it.outcome != "TO_HOT" or it.current_tier == "HOT":
             continue
-        moves.append(it)
+        if not it.warm_disk_files:
+            log.warning("Moves: [SKIP] %s [TO_HOT] — no warm_disk_files (tier detection inactive?)",
+                        it.title_year)
+            continue
+        to_hot_move.append(it)
 
-    all_to_hot = len(to_hot_skip) + len(moves)
-    if not all_to_hot:
-        log.info("Moves: no actionable TO_HOT items")
+    # TO_WARM: item is on the hot pool; hot_pool_files must be populated.
+    to_warm_move: List["Item"] = []
+    for it in items:
+        if it.outcome != "TO_WARM":
+            continue
+        if not it.hot_pool_files:
+            log.warning("Moves: [SKIP] %s [TO_WARM] — no hot_pool_files (tier detection inactive?)",
+                        it.title_year)
+            continue
+        to_warm_move.append(it)
+
+    # RELOCATE_WARM: item is on an evicting disk; warm_disk_files must be populated.
+    relocate_move: List["Item"] = []
+    for it in items:
+        if it.outcome != "RELOCATE_WARM":
+            continue
+        if not it.warm_disk_files:
+            log.warning("Moves: [SKIP] %s [RELOCATE_WARM] — no warm_disk_files (tier detection inactive?)",
+                        it.title_year)
+            continue
+        relocate_move.append(it)
+
+    if not (to_hot_skip or to_hot_move or to_warm_move or relocate_move):
+        log.info("Moves: no actionable items")
         return
 
-    total_bytes = sum(it.size_bytes for it in moves)
+    # --- Pre-select warm destinations (shared between dry-run and apply) ---
+    # Capacity failures are reported as errors immediately so they appear even
+    # in dry-run; the items are then excluded from the move queue.
 
+    to_warm_dests: Dict[int, Tuple[Optional[str], Optional[str]]] = {}
+    for it in to_warm_move:
+        if not array_disks:
+            to_warm_dests[id(it)] = (None, "no warm disks configured")
+        else:
+            dst, annot = _select_warm_destination(it, array_disks, safety_margin_bytes)
+            to_warm_dests[id(it)] = (dst, annot)
+        if to_warm_dests[id(it)][0] is None:
+            log.error("Moves: [FAILED] %s [TO_WARM] — %s (needs %s + %d GB margin)",
+                      it.title_year, to_warm_dests[id(it)][1],
+                      _fmt_size(it.size_bytes / (1024 ** 3)),
+                      (safety_margin_bytes // (1024 ** 3)))
+
+    relocate_dests: Dict[int, Tuple[Optional[str], Optional[str]]] = {}
+    for it in relocate_move:
+        if not array_disks:
+            relocate_dests[id(it)] = (None, "no warm disks configured")
+        else:
+            dst, annot = _select_warm_destination(
+                it, array_disks, safety_margin_bytes, exclude_disk=it.current_disk,
+            )
+            relocate_dests[id(it)] = (dst, annot)
+        if relocate_dests[id(it)][0] is None:
+            log.error("Moves: [FAILED] %s [RELOCATE_WARM] — %s (needs %s + %d GB margin)",
+                      it.title_year, relocate_dests[id(it)][1],
+                      _fmt_size(it.size_bytes / (1024 ** 3)),
+                      (safety_margin_bytes // (1024 ** 3)))
+
+    to_warm_ok = [it for it in to_warm_move if to_warm_dests[id(it)][0] is not None]
+    relocate_ok = [it for it in relocate_move if relocate_dests[id(it)][0] is not None]
+
+    total_bytes = (
+        sum(it.size_bytes for it in to_hot_move)
+        + sum(it.size_bytes for it in to_warm_ok)
+        + sum(it.size_bytes for it in relocate_ok)
+    )
+
+    # --- DRY-RUN ---
     if not apply:
-        eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
+        eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS) if total_bytes else "0s"
         log.info(
-            "[DRY-RUN] Moves: TO_HOT=%d (%d skipped already-HOT) — %s total — estimated %s at 200 MB/s",
-            len(moves), len(to_hot_skip),
+            "[DRY-RUN] Moves: TO_HOT=%d TO_WARM=%d RELOCATE_WARM=%d"
+            " (%d already-HOT skipped) — %s total — ETA ~%s at 200 MB/s",
+            len(to_hot_move), len(to_warm_ok), len(relocate_ok),
+            len(to_hot_skip),
             _fmt_size(total_bytes / (1024 ** 3)),
             eta,
         )
         for it in to_hot_skip:
-            log.info("[DRY-RUN]   %s — already on hot pool (SKIPPED)", it.title_year)
-        for it in moves:
+            log.info("[DRY-RUN]   %s [TO_HOT] — already on hot pool (SKIPPED)", it.title_year)
+        for it in to_hot_move:
             n_files = sum(len(f) for f in it.warm_disk_files.values())
-            for disk, files in it.warm_disk_files.items():
-                log.info(
-                    "[DRY-RUN]   %s — %s — %d file(s) from %s → %s",
-                    it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
-                    n_files, disk, hot_mount,
-                )
+            log.info(
+                "[DRY-RUN]   %s [TO_HOT] — %s — %d file(s) from %s → %s",
+                it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
+                n_files, it.current_disk or "?", hot_mount,
+            )
+        for it in to_warm_ok:
+            dst, annot = to_warm_dests[id(it)]
+            log.info(
+                "[DRY-RUN]   %s [TO_WARM] — %s — %d file(s) from %s → %s (%s)",
+                it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
+                len(it.hot_pool_files), hot_mount, dst, annot,
+            )
+        for it in relocate_ok:
+            dst, annot = relocate_dests[id(it)]
+            n_files = sum(len(f) for f in it.warm_disk_files.values())
+            log.info(
+                "[DRY-RUN]   %s [RELOCATE_WARM] — %s — %d file(s) from %s → %s (%s)",
+                it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
+                n_files, it.current_disk or "?", dst, annot,
+            )
         return
 
-    # --apply mode.
+    # --- APPLY MODE ---
     parity_blocking = moves_cfg.get("parity_check_blocking", True)
     if _check_parity_in_progress():
         if parity_blocking:
@@ -1922,174 +2240,106 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     bwlimit = moves_cfg.get("bandwidth_limit_mbps")
     if bwlimit:
         rsync_opts.append(f"--bwlimit={int(bwlimit) * 1024}")  # rsync expects KB/s
-
     delete_after = moves_cfg.get("delete_source_after_verify", True)
     size_verify = moves_cfg.get("size_verify", True)
 
-    eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS)
+    eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS) if total_bytes else "0s"
     log.info(
-        "Moves: TO_HOT=%d (apply mode) — %s total — ETA ~%s",
-        len(moves), _fmt_size(total_bytes / (1024 ** 3)), eta,
+        "Moves: TO_HOT=%d TO_WARM=%d RELOCATE_WARM=%d (apply mode) — %s total — ETA ~%s",
+        len(to_hot_move), len(to_warm_ok), len(relocate_ok),
+        _fmt_size(total_bytes / (1024 ** 3)), eta,
     )
     for it in to_hot_skip:
-        log.info("  [SKIPPED] %s — already on hot pool (no-op)", it.title_year)
+        log.info("  [SKIPPED] %s [TO_HOT] — already on hot pool (no-op)", it.title_year)
 
-    n_success = n_skipped = n_failed = 0
+    # Build unified move list: (direction, item, files_by_src_root, dst_root, src_label, dst_label, annotation)
+    # files_by_src_root matches what _exec_single_move expects: {src_root: [absolute file paths]}
+    move_list: list = []
+
+    for it in to_hot_move:
+        move_list.append((
+            "TO_HOT", it,
+            dict(it.warm_disk_files),
+            hot_mount.rstrip("/") + "/",
+            it.current_disk or "?", hot_mount, "",
+        ))
+    for it in to_warm_ok:
+        dst, annot = to_warm_dests[id(it)]
+        move_list.append((
+            "TO_WARM", it,
+            {hot_mount: it.hot_pool_files},
+            dst.rstrip("/") + "/",
+            hot_mount, dst, annot or "",
+        ))
+    for it in relocate_ok:
+        dst, annot = relocate_dests[id(it)]
+        move_list.append((
+            "RELOCATE_WARM", it,
+            dict(it.warm_disk_files),
+            dst.rstrip("/") + "/",
+            it.current_disk or "?", dst, annot or "",
+        ))
+
+    n_success = 0
     n_skipped = len(to_hot_skip)
+    n_failed = 0
     affected_libraries: set = set()
     run_start = datetime.now(timezone.utc)
+    total_count = len(move_list)
 
-    for idx, it in enumerate(moves, 1):
-        prefix = f"  [{idx}/{len(moves)}]"
+    for idx, (direction, it, files_by_src, dst_root, src_label, dst_label, annot) in enumerate(move_list, 1):
+        prefix = f"  [{idx}/{total_count}]"
         item_start = datetime.now(timezone.utc)
         size_str = _fmt_size(it.size_bytes / (1024 ** 3))
-        n_files = sum(len(f) for f in it.warm_disk_files.values())
+        n_files = sum(len(f) for f in files_by_src.values())
+        annot_sfx = f" ({annot})" if annot else ""
 
-        # Log before starting — long rsyncs are otherwise silent.
-        log.info("%s Moving %s — %s, %d file(s)", prefix, it.title_year, size_str, n_files)
-        for disk, files in it.warm_disk_files.items():
-            log.info("%s   %s (%d files) → %s", prefix, disk, len(files), hot_mount)
+        log.info(
+            "%s Moving %s [%s] — %s, %d file(s) — %s → %s%s",
+            prefix, it.title_year, direction, size_str, n_files,
+            src_label, dst_label, annot_sfx,
+        )
 
-        # rsync each warm disk using --files-from so only this item's files are
-        # transferred, regardless of whether the library uses per-item folders or
-        # shared year folders. Source root is the disk mount; destination root is
-        # the hot pool mount — rsync preserves the full relative path structure.
-        import tempfile as _tempfile
-        rsync_failed = False
-        for disk, files in it.warm_disk_files.items():
-            disk_root = disk.rstrip("/") + "/"
-            # Build relative paths (strip leading disk root + separator).
-            rel_paths = [f[len(disk_root):] if f.startswith(disk_root) else f.lstrip("/")
-                         for f in files]
-            try:
-                with _tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".txt", delete=False, prefix="tier_rsync_"
-                ) as flist:
-                    flist.write("\n".join(rel_paths))
-                    flist_path = flist.name
-            except OSError as exc:
-                log.error("%s [FAILED] %s — cannot write files-from list: %s",
-                          prefix, it.title_year, exc)
-                rsync_failed = True
-                break
-            try:
-                cmd = (["rsync"] + rsync_opts
-                       + [f"--files-from={flist_path}", disk_root, hot_mount.rstrip("/") + "/"])
-                result = subprocess.run(cmd, capture_output=True, text=True)
-            except OSError as exc:
-                log.error("%s [FAILED] %s — rsync failed to start: %s",
-                          prefix, it.title_year, exc)
-                rsync_failed = True
-            finally:
-                try:
-                    os.unlink(flist_path)
-                except OSError:
-                    pass
-            if rsync_failed:
-                break
-            if result.returncode != 0:
-                stderr_lines = (result.stderr or "").strip().splitlines()[:5]
-                stderr_str = "; ".join(stderr_lines) if stderr_lines else ""
-                log.error(
-                    "%s [FAILED] %s — rsync exit %d (disk=%s)%s — source unchanged",
-                    prefix, it.title_year, result.returncode, disk,
-                    f": {stderr_str}" if stderr_str else "",
-                )
-                rsync_failed = True
-                break
-        if rsync_failed:
-            n_failed += 1
-            continue
-
-        # Size verification: compare source file sizes against destination file
-        # sizes using os.path.getsize per file. File-level measurement is immune
-        # to concurrent downloads into the same directory (only the specific
-        # transferred files are measured, not the whole directory total).
-        if size_verify:
-            try:
-                src_sz = dst_sz = 0
-                hot = hot_mount.rstrip("/")
-                for disk, files in it.warm_disk_files.items():
-                    disk_root = disk.rstrip("/")
-                    for f in files:
-                        src_sz += os.path.getsize(f)
-                        dst_f = hot + f[len(disk_root):]
-                        if os.path.exists(dst_f):
-                            dst_sz += os.path.getsize(dst_f)
-                if abs(src_sz - dst_sz) > 1024:
-                    log.error(
-                        "%s [FAILED] %s — size verify failed (src=%s dst=%s) — source unchanged",
-                        prefix, it.title_year, src_sz, dst_sz,
-                    )
-                    n_failed += 1
-                    continue
-            except Exception as exc:  # noqa: BLE001
-                log.error(
-                    "%s [FAILED] %s — size verify error: %s — source unchanged",
-                    prefix, it.title_year, exc,
-                )
-                n_failed += 1
-                continue
-
-        # Delete source files individually, then prune empty parent directories.
-        # File-level delete means only this item's files are removed — other
-        # items sharing the same parent directory (e.g. a year folder) are safe.
-        if delete_after:
-            delete_failed = False
-            # Per-disk set of leaf dirs that need ancestor pruning.
-            disk_leaf_dirs: Dict[str, set] = {}
-            for disk, files in it.warm_disk_files.items():
-                disk_leaf_dirs[disk] = set()
-                for f in files:
-                    try:
-                        os.unlink(f)
-                        disk_leaf_dirs[disk].add(os.path.dirname(f))
-                    except OSError as exc:
-                        log.warning(
-                            "%s [SUCCESS*] %s — moved OK but source removal failed (%s): %s",
-                            prefix, it.title_year, f, exc,
-                        )
-                        delete_failed = True
-            # Prune empty ancestor directories up to (but not including) each
-            # disk root. Walk every ancestor so season dirs, show dirs, etc.
-            # are removed when they empty out. Each disk is handled with its
-            # own root so multi-disk series prune correctly on every disk.
-            all_dirs: set = set()
-            for disk, leaf_dirs in disk_leaf_dirs.items():
-                disk_root = disk.rstrip("/")
-                for d in leaf_dirs:
-                    current = d
-                    while current and current != disk_root and current.startswith(disk_root + "/"):
-                        all_dirs.add(current)
-                        current = os.path.dirname(current)
-            for d in sorted(all_dirs, reverse=True):
-                try:
-                    os.rmdir(d)  # no-op if directory still has content
-                except OSError:
-                    pass
-            if delete_failed:
-                n_success += 1
-                affected_libraries.add(it.library)
-                continue
+        status = _exec_single_move(
+            prefix=prefix,
+            title_year=it.title_year,
+            files_by_src_root=files_by_src,
+            dst_root=dst_root,
+            rsync_opts=rsync_opts,
+            size_verify=size_verify,
+            delete_after=delete_after,
+        )
 
         elapsed = (datetime.now(timezone.utc) - item_start).total_seconds()
-        log.info(
-            "%s [SUCCESS] %s — %s in %s — %s → %s",
-            prefix, it.title_year, size_str, _fmt_eta(elapsed),
-            it.current_disk, hot_mount,
-        )
-        n_success += 1
-        affected_libraries.add(it.library)
+        if status == "failed":
+            n_failed += 1
+        else:
+            log.info(
+                "%s [SUCCESS] %s [%s] — %s in %s — %s → %s%s",
+                prefix, it.title_year, direction, size_str, _fmt_eta(elapsed),
+                src_label, dst_label, annot_sfx,
+            )
+            n_success += 1
+            affected_libraries.add(it.library)
 
     total_elapsed = (datetime.now(timezone.utc) - run_start).total_seconds()
     log.info(
         "Moves complete: %d successful, %d skipped, %d failed (%s total)",
         n_success, n_skipped, n_failed, _fmt_eta(total_elapsed),
     )
-    if affected_libraries:
+    # TO_HOT moves bring files to a mount outside the Unraid user-share union,
+    # so Plex needs a library rescan to see the new paths. TO_WARM and
+    # RELOCATE_WARM keep files within /mnt/user/ — no rescan required since
+    # Plex always reads through the union regardless of which physical disk
+    # backs the file.
+    hot_libraries = {
+        it.library for (direction, it, *_) in move_list
+        if direction == "TO_HOT" and it.library in affected_libraries
+    }
+    if hot_libraries:
         log.info(
             "Plex rescan recommended for sections: %s",
-            ", ".join(sorted(affected_libraries)),
+            ", ".join(sorted(hot_libraries)),
         )
 
 
@@ -3727,7 +3977,7 @@ def _test_companion_files_included_in_warm_disk_files():
                 fh.write(b"x" * 100)
 
         parts = [(mkv, 100)]
-        tier, _, _, _, wdf = resolve_item_current_tier(
+        tier, _, _, _, wdf, _hot = resolve_item_current_tier(
             parts=parts,
             path_map=[],
             hot_mount=hot_mount,
@@ -3742,6 +3992,336 @@ def _test_companion_files_included_in_warm_disk_files():
         assert unrelated not in files, f"unrelated file must not be included: {files}"
 
     print("_test_companion_files_included_in_warm_disk_files: OK")
+
+
+def _test_warm_disk_selection_to_warm_picks_most_free():
+    """TO_WARM with two candidate disks — selects the one with most free space."""
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        free_map = {"/mnt/disk1": 100 * 1024 ** 3, "/mnt/disk2": 200 * 1024 ** 3}
+        _disk_free_bytes = lambda p: free_map.get(p, 0)  # noqa: E731
+
+        item = _make_item(kind="movie", size_bytes=10 * 1024 ** 3)
+        disk, annot = _select_warm_destination(
+            item, ["/mnt/disk1", "/mnt/disk2"], safety_margin_bytes=0
+        )
+        assert disk == "/mnt/disk2", f"expected disk2 (most-free), got {disk}"
+        assert annot == "most-free", f"expected most-free, got {annot}"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_warm_disk_selection_to_warm_picks_most_free: OK")
+
+
+def _test_warm_disk_selection_relocate_excludes_source():
+    """RELOCATE_WARM excludes current_disk from candidates."""
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        # disk1 is the evicting source, disk2 has space
+        free_map = {"/mnt/disk1": 500 * 1024 ** 3, "/mnt/disk2": 200 * 1024 ** 3}
+        _disk_free_bytes = lambda p: free_map.get(p, 0)  # noqa: E731
+
+        item = _make_item(kind="movie", size_bytes=10 * 1024 ** 3)
+        disk, annot = _select_warm_destination(
+            item, ["/mnt/disk1", "/mnt/disk2"],
+            safety_margin_bytes=0, exclude_disk="/mnt/disk1",
+        )
+        assert disk == "/mnt/disk2", f"source disk must be excluded, got {disk}"
+        assert annot == "most-free"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_warm_disk_selection_relocate_excludes_source: OK")
+
+
+def _test_warm_disk_selection_co_locate_for_series():
+    """Series with warm bytes already on disk2 — co-location wins over most-free."""
+    import tempfile, os as _os
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        with tempfile.TemporaryDirectory() as root:
+            disk2 = _os.path.join(root, "disk2")
+            show_dir = _os.path.join(disk2, "TV Shows", "Reba (2001)")
+            _os.makedirs(show_dir, exist_ok=True)
+            ep_file = _os.path.join(show_dir, "S01E01.mkv")
+            with open(ep_file, "wb") as fh:
+                fh.write(b"x" * (5 * 1024 ** 3))  # 5 GB already on disk2
+
+            free_map = {"/mnt/disk1": 400 * 1024 ** 3, disk2: 200 * 1024 ** 3}
+            _disk_free_bytes = lambda p: free_map.get(p, 0)  # noqa: E731
+
+            item = _make_item(
+                kind="series", size_bytes=20 * 1024 ** 3,
+                warm_disk_files={disk2: [ep_file]},
+            )
+            disk, annot = _select_warm_destination(
+                item, ["/mnt/disk1", disk2], safety_margin_bytes=0
+            )
+            assert disk == disk2, f"expected co-location on disk2, got {disk}"
+            assert annot and "co-locate" in annot, f"expected co-locate annotation, got {annot}"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_warm_disk_selection_co_locate_for_series: OK")
+
+
+def _test_warm_disk_selection_no_capacity_returns_none():
+    """No disk has enough space — returns (None, reason)."""
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        _disk_free_bytes = lambda _: 1 * 1024 ** 3  # 1 GB free everywhere  # noqa: E731
+        item = _make_item(size_bytes=100 * 1024 ** 3)
+        disk, annot = _select_warm_destination(
+            item, ["/mnt/disk1"], safety_margin_bytes=0
+        )
+        assert disk is None, f"expected None, got {disk}"
+        assert annot is not None, "expected failure reason string"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_warm_disk_selection_no_capacity_returns_none: OK")
+
+
+def _test_warm_disk_selection_safety_margin_respected():
+    """Disk has item.size_bytes free but not item.size_bytes + margin — excluded."""
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        item_bytes = 10 * 1024 ** 3
+        margin_bytes = 50 * 1024 ** 3
+        # Disk has exactly item_bytes free — not enough with the margin
+        _disk_free_bytes = lambda _: item_bytes  # noqa: E731
+        item = _make_item(size_bytes=item_bytes)
+        disk, _ = _select_warm_destination(
+            item, ["/mnt/disk1"], safety_margin_bytes=margin_bytes
+        )
+        assert disk is None, f"margin not respected — got disk={disk}"
+
+        # Disk has item_bytes + margin free — should qualify
+        _disk_free_bytes = lambda _: item_bytes + margin_bytes  # noqa: E731
+        disk2, _ = _select_warm_destination(
+            item, ["/mnt/disk1"], safety_margin_bytes=margin_bytes
+        )
+        assert disk2 == "/mnt/disk1", f"should qualify with exact margin, got {disk2}"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_warm_disk_selection_safety_margin_respected: OK")
+
+
+def _test_to_warm_full_flow_end_to_end():
+    """TO_WARM: hot pool files are rsynced to chosen warm disk; source deleted."""
+    import tempfile, os as _os, subprocess as _sp
+
+    with tempfile.TemporaryDirectory() as root:
+        hot = _os.path.join(root, "zfs_media")
+        disk1 = _os.path.join(root, "disk1")
+        movie_dir = _os.path.join(hot, "Movies", "Interstellar (2014)")
+        _os.makedirs(movie_dir, exist_ok=True)
+        _os.makedirs(disk1, exist_ok=True)
+
+        mkv = _os.path.join(movie_dir, "Interstellar.mkv")
+        with open(mkv, "wb") as fh:
+            fh.write(b"x" * 1000)
+
+        # Build Item as if it were HOT with hot_pool_files populated
+        item = _make_item(
+            kind="movie", size_bytes=1000,
+            current_tier="HOT",
+            hot_pool_files=[mkv],
+            warm_disk_files={},
+        )
+        item.outcome = "TO_WARM"
+
+        rsync_calls = []
+        orig_run = _sp.run
+
+        def _fake_rsync(cmd, **_):
+            rsync_calls.append(cmd)
+            # Actually copy the file so size-verify passes
+            import shutil as _sh
+            src_root = cmd[-2]
+            dst_root = cmd[-1]
+            ff_path = [a for a in cmd if a.startswith("--files-from=")][0].split("=", 1)[1]
+            with open(ff_path) as f:
+                for rel in f.read().splitlines():
+                    src = _os.path.join(src_root, rel)
+                    dst = _os.path.join(dst_root, rel)
+                    _os.makedirs(_os.path.dirname(dst), exist_ok=True)
+                    _sh.copy2(src, dst)
+
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        _sp.run = _fake_rsync
+        try:
+            status = _exec_single_move(
+                prefix="[1/1]",
+                title_year="Interstellar (2014)",
+                files_by_src_root={hot: [mkv]},
+                dst_root=disk1 + "/",
+                rsync_opts=["-aH"],
+                size_verify=True,
+                delete_after=True,
+            )
+        finally:
+            _sp.run = orig_run
+
+        assert status == "ok", f"expected ok, got {status}"
+        assert not _os.path.exists(mkv), "source file must be deleted after verify"
+        dst_mkv = _os.path.join(disk1, "Movies", "Interstellar (2014)", "Interstellar.mkv")
+        assert _os.path.exists(dst_mkv), f"destination file not found: {dst_mkv}"
+        assert len(rsync_calls) == 1, f"expected 1 rsync call, got {len(rsync_calls)}"
+        # Source root in rsync command must be the hot mount, not the warm disk
+        assert hot.rstrip("/") + "/" in rsync_calls[0], "rsync source must be hot pool"
+
+    print("_test_to_warm_full_flow_end_to_end: OK")
+
+
+def _test_relocate_warm_full_flow_end_to_end():
+    """RELOCATE_WARM: files rsynced from current_disk to chosen disk; source disk excluded."""
+    import tempfile, os as _os, subprocess as _sp
+
+    with tempfile.TemporaryDirectory() as root:
+        disk7 = _os.path.join(root, "disk7")  # evicting source
+        disk4 = _os.path.join(root, "disk4")  # destination
+        show_dir = _os.path.join(disk7, "TV Shows", "Reba (2001)")
+        _os.makedirs(show_dir, exist_ok=True)
+        _os.makedirs(disk4, exist_ok=True)
+
+        ep = _os.path.join(show_dir, "S01E01.mkv")
+        with open(ep, "wb") as fh:
+            fh.write(b"x" * 1000)
+
+        item = _make_item(
+            kind="series", size_bytes=1000,
+            current_tier="WARM", current_disk=disk7,
+            warm_disk_files={disk7: [ep]},
+        )
+        item.outcome = "RELOCATE_WARM"
+
+        rsync_calls = []
+        orig_run = _sp.run
+
+        def _fake_rsync(cmd, **_):
+            rsync_calls.append(cmd)
+            import shutil as _sh
+            src_root = cmd[-2]
+            dst_root = cmd[-1]
+            ff_path = [a for a in cmd if a.startswith("--files-from=")][0].split("=", 1)[1]
+            with open(ff_path) as f:
+                for rel in f.read().splitlines():
+                    src = _os.path.join(src_root, rel)
+                    dst = _os.path.join(dst_root, rel)
+                    _os.makedirs(_os.path.dirname(dst), exist_ok=True)
+                    _sh.copy2(src, dst)
+
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        _sp.run = _fake_rsync
+        try:
+            status = _exec_single_move(
+                prefix="[1/1]",
+                title_year="Reba (2001)",
+                files_by_src_root={disk7: [ep]},
+                dst_root=disk4 + "/",
+                rsync_opts=["-aH"],
+                size_verify=True,
+                delete_after=True,
+            )
+        finally:
+            _sp.run = orig_run
+
+        assert status == "ok", f"expected ok, got {status}"
+        assert not _os.path.exists(ep), "source file must be deleted"
+        dst_ep = _os.path.join(disk4, "TV Shows", "Reba (2001)", "S01E01.mkv")
+        assert _os.path.exists(dst_ep), f"destination not found: {dst_ep}"
+        # Confirm rsync source was disk7, not disk4
+        assert disk7.rstrip("/") + "/" in rsync_calls[0], "rsync must use evicting disk as source"
+        assert disk4.rstrip("/") + "/" not in rsync_calls[0][:-1], "evicting disk must not appear as rsync dest source"
+
+    print("_test_relocate_warm_full_flow_end_to_end: OK")
+
+
+def _test_relocate_warm_co_locate_with_existing_partial():
+    """RELOCATE_WARM: if destination already has partial series, rsync merges correctly."""
+    import tempfile, os as _os, subprocess as _sp
+
+    with tempfile.TemporaryDirectory() as root:
+        disk7 = _os.path.join(root, "disk7")  # evicting disk (has S01)
+        disk4 = _os.path.join(root, "disk4")  # destination (already has S02)
+
+        s01_dir = _os.path.join(disk7, "TV Shows", "Reba (2001)", "Season 01")
+        s02_dir = _os.path.join(disk4, "TV Shows", "Reba (2001)", "Season 02")
+        _os.makedirs(s01_dir, exist_ok=True)
+        _os.makedirs(s02_dir, exist_ok=True)
+
+        ep1 = _os.path.join(s01_dir, "S01E01.mkv")
+        ep2 = _os.path.join(s02_dir, "S02E01.mkv")
+        for f in (ep1, ep2):
+            with open(f, "wb") as fh:
+                fh.write(b"x" * 500)
+
+        # Item has warm bytes on disk7 (evicting) and disk4 (co-locate target).
+        # Not passed to _exec_single_move; created for documentation only.
+        _item = _make_item(
+            kind="series", size_bytes=1000,
+            current_tier="WARM", current_disk=disk7,
+            warm_disk_files={disk7: [ep1], disk4: [ep2]},
+        )
+        _ = _item  # suppress unused-variable hint
+
+        rsync_calls = []
+        orig_run = _sp.run
+
+        def _fake_rsync(cmd, **_):
+            rsync_calls.append(list(cmd))
+            import shutil as _sh
+            src_root = cmd[-2]
+            dst_root = cmd[-1]
+            ff_path = [a for a in cmd if a.startswith("--files-from=")][0].split("=", 1)[1]
+            with open(ff_path) as f:
+                for rel in f.read().splitlines():
+                    src = _os.path.join(src_root, rel)
+                    dst = _os.path.join(dst_root, rel)
+                    if _os.path.exists(src) and src != dst:
+                        _os.makedirs(_os.path.dirname(dst), exist_ok=True)
+                        _sh.copy2(src, dst)
+
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        _sp.run = _fake_rsync
+        try:
+            # Relocate all warm files (disk7 + disk4) to disk4 as destination.
+            # The disk4 source entries have src == dst (already in place);
+            # the fake rsync skips same-file copies, mirroring real rsync behaviour.
+            status = _exec_single_move(
+                prefix="[1/1]",
+                title_year="Reba (2001)",
+                files_by_src_root={disk7: [ep1], disk4: [ep2]},
+                dst_root=disk4 + "/",
+                rsync_opts=["-aH"],
+                size_verify=True,
+                delete_after=False,  # don't delete in this test to simplify
+            )
+        finally:
+            _sp.run = orig_run
+
+        assert status == "ok", f"expected ok, got {status}"
+        # Two rsync calls: one per source disk
+        assert len(rsync_calls) == 2, f"expected 2 rsync calls (one per source disk), got {len(rsync_calls)}"
+        src_roots = [c[-2] for c in rsync_calls]
+        assert disk7.rstrip("/") + "/" in src_roots, "disk7 must be a rsync source"
+        assert disk4.rstrip("/") + "/" in src_roots, "disk4 must be a rsync source (merge)"
+
+    print("_test_relocate_warm_co_locate_with_existing_partial: OK")
 
 
 if __name__ == "__main__":
@@ -3788,5 +4368,13 @@ if __name__ == "__main__":
         _test_size_verify_mixed_tier_preexisting_dst_passes()
         _test_companion_files_included_in_warm_disk_files()
         _test_empty_ancestor_dirs_pruned_after_delete()
+        _test_warm_disk_selection_to_warm_picks_most_free()
+        _test_warm_disk_selection_relocate_excludes_source()
+        _test_warm_disk_selection_co_locate_for_series()
+        _test_warm_disk_selection_no_capacity_returns_none()
+        _test_warm_disk_selection_safety_margin_respected()
+        _test_to_warm_full_flow_end_to_end()
+        _test_relocate_warm_full_flow_end_to_end()
+        _test_relocate_warm_co_locate_with_existing_partial()
         sys.exit(0)
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -707,6 +707,36 @@ def classify_path(
     return "UNKNOWN"
 
 
+# Matches sort-title article form: "Bounty Hunter, The (2010)" or "Bounty Hunter, The"
+_SORT_TITLE_RE = re.compile(r'^(.+),\s+(the|a|an)\s*(\(\d{4}\))?\s*$', re.IGNORECASE)
+
+
+def _is_movie_per_folder(parent_name: str, stem: str) -> bool:
+    """Return True when parent_name and stem refer to the same movie title.
+
+    Handles two naming conventions:
+    - Exact: 'Austin Powers (2002)' folder + 'Austin Powers (2002).mkv'
+    - Sort-title inversion: 'The Bounty Hunter (2010)' folder +
+      'Bounty Hunter, The (2010).mkv' (Plex renames articles to the end).
+    """
+    if parent_name.lower() == stem.lower():
+        return True
+
+    def _strip(s: str) -> str:
+        s = s.strip()
+        for art in ("the ", "a ", "an "):
+            if s.lower().startswith(art):
+                return s[len(art):]
+        m = _SORT_TITLE_RE.match(s)
+        if m:
+            base = m.group(1).strip()
+            year = (m.group(3) or "").strip()
+            return (base + (" " + year if year else "")).strip()
+        return s
+
+    return _strip(parent_name).lower() == _strip(stem).lower()
+
+
 def _find_companion_files(media_path: str) -> List[str]:
     """Return sibling files in the same directory that should move with media_path.
 
@@ -726,14 +756,14 @@ def _find_companion_files(media_path: str) -> List[str]:
     the subtitle/NFO companion case for year-organised libraries where
     multiple movies share one folder.
 
-    Detection: case-insensitive exact match between parent directory name and
-    media file stem.  Year folders (e.g. '2002') never match a movie stem.
-    Flat library roots (e.g. 'Movies') never match either.
+    Detection: _is_movie_per_folder() — handles exact match and article
+    inversions ('The Foo' folder / 'Foo, The.mkv' sort-title convention).
+    Year folders ('2002') and library roots ('Movies') never match.
     """
     parent = os.path.dirname(media_path)
     stem = os.path.splitext(os.path.basename(media_path))[0]
     parent_name = os.path.basename(parent)
-    movie_per_folder = parent_name.lower() == stem.lower()
+    movie_per_folder = _is_movie_per_folder(parent_name, stem)
     companions: List[str] = []
     try:
         with os.scandir(parent) as it:
@@ -841,7 +871,7 @@ def resolve_item_current_tier(
             for mf in files:
                 parent = os.path.dirname(mf)
                 stem = os.path.splitext(os.path.basename(mf))[0]
-                if os.path.basename(parent).lower() != stem.lower():
+                if not _is_movie_per_folder(os.path.basename(parent), stem):
                     continue  # not a movie-per-folder layout; skip
                 if not mf.startswith(d + "/"):
                     continue
@@ -4168,6 +4198,23 @@ def _test_cross_tier_companion_probe():
     print("_test_cross_tier_companion_probe: OK")
 
 
+def _test_movie_per_folder_article_inversion():
+    """_is_movie_per_folder matches when folder uses natural title, file uses sort-title article form."""
+    # Exact match still works
+    assert _is_movie_per_folder("Austin Powers (2002)", "Austin Powers (2002)")
+    # Article at start of folder, moved to end in file stem (Plex sort-title convention)
+    assert _is_movie_per_folder("The Bounty Hunter (2010)", "Bounty Hunter, The (2010)")
+    assert _is_movie_per_folder("A Beautiful Mind (2001)", "Beautiful Mind, A (2001)")
+    assert _is_movie_per_folder("An American Werewolf in London (1981)", "American Werewolf in London, An (1981)")
+    # Case-insensitive
+    assert _is_movie_per_folder("the bounty hunter (2010)", "Bounty Hunter, The (2010)")
+    # Unrelated titles must not match
+    assert not _is_movie_per_folder("The Matrix (1999)", "Bounty Hunter, The (2010)")
+    # Same title without year mismatch
+    assert _is_movie_per_folder("The Bounty Hunter", "Bounty Hunter, The")
+    print("_test_movie_per_folder_article_inversion: OK")
+
+
 def _test_straggler_stay_warm_upgraded_to_to_warm():
     """STAY_WARM item with hot_pool_files is upgraded to TO_WARM by collect_all."""
     item = _make_item(kind="movie", size_bytes=100)
@@ -4630,6 +4677,7 @@ if __name__ == "__main__":
         _test_companion_files_included_in_warm_disk_files()
         _test_movie_per_folder_extras_included()
         _test_cross_tier_companion_probe()
+        _test_movie_per_folder_article_inversion()
         _test_straggler_stay_warm_upgraded_to_to_warm()
         _test_straggler_stay_hot_upgraded_to_to_hot()
         _test_straggler_no_upgrade_when_no_wrong_tier_files()

--- a/tier.py
+++ b/tier.py
@@ -702,19 +702,32 @@ def classify_path(
 
 
 def _find_companion_files(media_path: str) -> List[str]:
-    """Return sidecar files in the same directory that share the media file's stem.
+    """Return sibling files in the same directory that should move with media_path.
 
-    Plex discovers external subtitles at play time by scanning the media
-    file's directory for files whose stem matches (or starts with the stem
-    followed by '.', to catch language tags like Movie.en.srt).  This
-    function replicates that logic so rsync moves companions alongside the
-    media file.
+    Two modes depending on folder structure:
 
-    Example: /disk/Movies/Moana (2016).mkv  →  finds:
-      Moana (2016).nfo, Moana (2016).en.srt, Moana (2016).sub, …
+    Movie-per-folder: when the parent directory name matches the media file's
+    stem (e.g. '.../Austin Powers in Goldmember (2002)/Austin Powers in
+    Goldmember (2002).mkv'), ALL other files in the directory are returned.
+    This covers Plex extras — trailers, featurettes, deleted scenes, etc. —
+    which Plex stores in the same folder using suffix conventions (-trailer,
+    -featurette, -deleted, …) and which have completely different stems from
+    the main title file.
+
+    Shared folder: when the parent is a year folder, library root, or any
+    other shared container (parent name != file stem), only files whose stem
+    equals the media stem or starts with stem + '.' are returned.  This is
+    the subtitle/NFO companion case for year-organised libraries where
+    multiple movies share one folder.
+
+    Detection: case-insensitive exact match between parent directory name and
+    media file stem.  Year folders (e.g. '2002') never match a movie stem.
+    Flat library roots (e.g. 'Movies') never match either.
     """
     parent = os.path.dirname(media_path)
     stem = os.path.splitext(os.path.basename(media_path))[0]
+    parent_name = os.path.basename(parent)
+    movie_per_folder = parent_name.lower() == stem.lower()
     companions: List[str] = []
     try:
         with os.scandir(parent) as it:
@@ -723,9 +736,12 @@ def _find_companion_files(media_path: str) -> List[str]:
                     continue
                 if entry.path == media_path:
                     continue
-                entry_stem = os.path.splitext(entry.name)[0]
-                if entry_stem == stem or entry_stem.startswith(stem + "."):
+                if movie_per_folder:
                     companions.append(entry.path)
+                else:
+                    entry_stem = os.path.splitext(entry.name)[0]
+                    if entry_stem == stem or entry_stem.startswith(stem + "."):
+                        companions.append(entry.path)
     except OSError:
         pass
     return companions
@@ -3957,20 +3973,21 @@ def _test_empty_ancestor_dirs_pruned_after_delete():
 
 
 def _test_companion_files_included_in_warm_disk_files():
-    """Companion files (nfo, srt, sub) are included in warm_disk_files alongside media."""
+    """Year-folder structure: srt/nfo companions included, unrelated movie excluded."""
     import tempfile, os as _os
 
     with tempfile.TemporaryDirectory() as root:
         disk = _os.path.join(root, "disk4")
         hot_mount = _os.path.join(root, "zfs_media")
-        movie_dir = _os.path.join(disk, "Movies", "Moana (2016)")
-        _os.makedirs(movie_dir, exist_ok=True)
+        # Year-folder structure: multiple movies share the '2016' folder.
+        year_dir = _os.path.join(disk, "Movies", "2016")
+        _os.makedirs(year_dir, exist_ok=True)
         _os.makedirs(hot_mount, exist_ok=True)
 
-        mkv = _os.path.join(movie_dir, "Moana (2016).mkv")
-        nfo = _os.path.join(movie_dir, "Moana (2016).nfo")
-        srt = _os.path.join(movie_dir, "Moana (2016).en.srt")
-        unrelated = _os.path.join(movie_dir, "other_movie.mkv")
+        mkv = _os.path.join(year_dir, "Moana (2016).mkv")
+        nfo = _os.path.join(year_dir, "Moana (2016).nfo")
+        srt = _os.path.join(year_dir, "Moana (2016).en.srt")
+        unrelated = _os.path.join(year_dir, "Other Movie (2016).mkv")
 
         for f in (mkv, nfo, srt, unrelated):
             with open(f, "wb") as fh:
@@ -3992,6 +4009,51 @@ def _test_companion_files_included_in_warm_disk_files():
         assert unrelated not in files, f"unrelated file must not be included: {files}"
 
     print("_test_companion_files_included_in_warm_disk_files: OK")
+
+
+def _test_movie_per_folder_extras_included():
+    """Movie-per-folder structure: ALL extras in the folder are included (any stem)."""
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk = _os.path.join(root, "disk5")
+        hot_mount = _os.path.join(root, "zfs_media")
+        # Hot pool copy — main movie + extras all in the movie's own folder.
+        movie_dir = _os.path.join(hot_mount, "DVD Rips", "Movies",
+                                  "Austin Powers in Goldmember (2002)")
+        _os.makedirs(movie_dir, exist_ok=True)
+        _os.makedirs(disk, exist_ok=True)
+
+        main_mkv = _os.path.join(movie_dir,
+                                 "Austin Powers in Goldmember (2002).mkv")
+        trailer  = _os.path.join(movie_dir,
+                                 "Austin Powers in Goldmember-trailer.mkv")
+        featurette = _os.path.join(movie_dir, "Disco Fever-featurette.mkv")
+        deleted  = _os.path.join(movie_dir, "Bloopers-deleted.mkv")
+        nfo      = _os.path.join(movie_dir,
+                                 "Austin Powers in Goldmember (2002).nfo")
+
+        for f in (main_mkv, trailer, featurette, deleted, nfo):
+            with open(f, "wb") as fh:
+                fh.write(b"x" * 100)
+
+        parts = [(main_mkv, 100)]
+        tier, _, _, _, _, hot = resolve_item_current_tier(
+            parts=parts,
+            path_map=[],
+            hot_mount=hot_mount,
+            array_disks=[disk],
+        )
+
+        assert tier == "HOT", f"expected HOT, got {tier}"
+        # All extras must be in hot_pool_files for TO_WARM to pick them up.
+        assert main_mkv in hot, f"main mkv missing: {hot}"
+        assert trailer in hot, f"trailer missing: {hot}"
+        assert featurette in hot, f"featurette missing: {hot}"
+        assert deleted in hot, f"deleted scene missing: {hot}"
+        assert nfo in hot, f"nfo missing: {hot}"
+
+    print("_test_movie_per_folder_extras_included: OK")
 
 
 def _test_warm_disk_selection_to_warm_picks_most_free():
@@ -4367,6 +4429,7 @@ if __name__ == "__main__":
         _test_multidisk_series_all_source_dirs_rsynced()
         _test_size_verify_mixed_tier_preexisting_dst_passes()
         _test_companion_files_included_in_warm_disk_files()
+        _test_movie_per_folder_extras_included()
         _test_empty_ancestor_dirs_pruned_after_delete()
         _test_warm_disk_selection_to_warm_picks_most_free()
         _test_warm_disk_selection_relocate_excludes_source()

--- a/tier.py
+++ b/tier.py
@@ -186,6 +186,12 @@ DEFAULT_CONFIG = {
         "size_verify": True,
         "parity_check_blocking": True,
         "bandwidth_limit_mbps": None,
+        # Initial throughput estimates for ETA at the start of each run.
+        # Actual speeds vary by hardware; adjust to match your environment.
+        # TO_HOT writes to the ZFS pool (NVMe/SSD); TO_WARM/RELOCATE_WARM
+        # write to spinning-disk array — typically much slower.
+        "estimated_hot_mbps": 200,
+        "estimated_warm_mbps": 50,
         "warm_disk_selection": {
             # How to pick the destination warm disk for TO_WARM / RELOCATE_WARM.
             # Only strategy in v1: prefer the disk that already holds the most
@@ -822,6 +828,40 @@ def resolve_item_current_tier(
                     seen.add(companion)
                     extras.append(companion)
         disk_files[disk].extend(extras)
+
+    # Cross-tier companion probe: for WARM files in movie-per-folder layouts,
+    # scan the equivalent hot pool directory for extras stranded by a prior
+    # partial move (main file already moved to warm, extras left on hot pool).
+    # Typical scenario: a prior run moved the main .mkv but not the featurettes,
+    # trailers, or deleted scenes in the same folder.
+    if hot_mount:
+        hot_probed: set = set()
+        for disk, files in disk_files.items():
+            d = disk.rstrip("/")
+            for mf in files:
+                parent = os.path.dirname(mf)
+                stem = os.path.splitext(os.path.basename(mf))[0]
+                if os.path.basename(parent).lower() != stem.lower():
+                    continue  # not a movie-per-folder layout; skip
+                if not mf.startswith(d + "/"):
+                    continue
+                rel = mf[len(d):]  # e.g. /DVD Rips/Movies/Title (YYYY)/Title (YYYY).mkv
+                hot_dir = os.path.dirname(hot_mount.rstrip("/") + rel)
+                if hot_dir in hot_probed:
+                    continue
+                hot_probed.add(hot_dir)
+                if not os.path.isdir(hot_dir):
+                    continue
+                try:
+                    with os.scandir(hot_dir) as scan_it:
+                        for entry in scan_it:
+                            if not entry.is_file(follow_symlinks=False):
+                                continue
+                            if entry.path not in seen:
+                                seen.add(entry.path)
+                                hot_files.append(entry.path)
+                except OSError:
+                    pass
 
     dominant = max(disk_bytes, key=disk_bytes.__getitem__) if disk_bytes else None
     # Build display-only source dirs (common ancestor per disk, dominant first).
@@ -1879,9 +1919,6 @@ def _fmt_eta(seconds: float) -> str:
 
 # ---------- Move executor (P2) ----------
 
-# Assumed throughput for ETA estimates (spinning array → ZFS NVMe).
-_ASSUMED_THROUGHPUT_BPS = 200 * 1024 * 1024  # 200 MB/s
-
 
 def _disk_free_bytes(path: str) -> int:
     """Return free bytes on the filesystem at path, or 0 on error."""
@@ -2136,6 +2173,8 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     warm_sel_cfg = (moves_cfg.get("warm_disk_selection") or {})
     safety_margin_bytes = int(float(warm_sel_cfg.get("safety_margin_gb") or 50) * 1024 ** 3)
+    hot_bps = int(float(moves_cfg.get("estimated_hot_mbps") or 200)) * 1024 * 1024
+    warm_bps = int(float(moves_cfg.get("estimated_warm_mbps") or 50)) * 1024 * 1024
 
     # Tally SHOULD_BE_* outcomes (tier unknown — nothing to move).
     skip_outcomes: dict = {}
@@ -2223,22 +2262,29 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     to_warm_ok = [it for it in to_warm_move if to_warm_dests[id(it)][0] is not None]
     relocate_ok = [it for it in relocate_move if relocate_dests[id(it)][0] is not None]
 
-    total_bytes = (
-        sum(it.size_bytes for it in to_hot_move)
-        + sum(it.size_bytes for it in to_warm_ok)
+    hot_bytes = sum(it.size_bytes for it in to_hot_move)
+    warm_bytes = (
+        sum(it.size_bytes for it in to_warm_ok)
         + sum(it.size_bytes for it in relocate_ok)
     )
+    total_bytes = hot_bytes + warm_bytes
+
+    def _eta() -> str:
+        secs = (hot_bytes / hot_bps if hot_bps and hot_bytes else 0.0) + \
+               (warm_bytes / warm_bps if warm_bps and warm_bytes else 0.0)
+        return _fmt_eta(secs) if secs else "0s"
 
     # --- DRY-RUN ---
     if not apply:
-        eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS) if total_bytes else "0s"
         log.info(
             "[DRY-RUN] Moves: TO_HOT=%d TO_WARM=%d RELOCATE_WARM=%d"
-            " (%d already-HOT skipped) — %s total — ETA ~%s at 200 MB/s",
+            " (%d already-HOT skipped) — %s total — ETA ~%s"
+            " (%d MB/s hot / %d MB/s warm)",
             len(to_hot_move), len(to_warm_ok), len(relocate_ok),
             len(to_hot_skip),
             _fmt_size(total_bytes / (1024 ** 3)),
-            eta,
+            _eta(),
+            hot_bps // (1024 * 1024), warm_bps // (1024 * 1024),
         )
         for it in to_hot_skip:
             log.info("[DRY-RUN]   %s [TO_HOT] — already on hot pool (SKIPPED)", it.title_year)
@@ -2281,11 +2327,12 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     delete_after = moves_cfg.get("delete_source_after_verify", True)
     size_verify = moves_cfg.get("size_verify", True)
 
-    eta = _fmt_eta(total_bytes / _ASSUMED_THROUGHPUT_BPS) if total_bytes else "0s"
     log.info(
-        "Moves: TO_HOT=%d TO_WARM=%d RELOCATE_WARM=%d (apply mode) — %s total — ETA ~%s",
+        "Moves: TO_HOT=%d TO_WARM=%d RELOCATE_WARM=%d (apply mode) — %s total — ETA ~%s"
+        " (%d MB/s hot / %d MB/s warm)",
         len(to_hot_move), len(to_warm_ok), len(relocate_ok),
-        _fmt_size(total_bytes / (1024 ** 3)), eta,
+        _fmt_size(total_bytes / (1024 ** 3)), _eta(),
+        hot_bps // (1024 * 1024), warm_bps // (1024 * 1024),
     )
     for it in to_hot_skip:
         log.info("  [SKIPPED] %s [TO_HOT] — already on hot pool (no-op)", it.title_year)
@@ -4078,6 +4125,49 @@ def _test_movie_per_folder_extras_included():
     print("_test_movie_per_folder_extras_included: OK")
 
 
+def _test_cross_tier_companion_probe():
+    """Main file moved to warm in a prior run; extras stranded on hot pool are discovered."""
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk = _os.path.join(root, "disk5")
+        hot_mount = _os.path.join(root, "zfs_media")
+        # Warm disk: only the main .mkv made it here in a prior run.
+        warm_movie_dir = _os.path.join(disk, "DVD Rips", "Movies",
+                                       "Austin Powers (2002)")
+        # Hot pool: main movie folder still has the extras that were never moved.
+        hot_movie_dir = _os.path.join(hot_mount, "DVD Rips", "Movies",
+                                      "Austin Powers (2002)")
+        _os.makedirs(warm_movie_dir, exist_ok=True)
+        _os.makedirs(hot_movie_dir, exist_ok=True)
+
+        main_warm = _os.path.join(warm_movie_dir, "Austin Powers (2002).mkv")
+        trailer_hot = _os.path.join(hot_movie_dir,
+                                    "Austin Powers-trailer.mkv")
+        featurette_hot = _os.path.join(hot_movie_dir, "Disco Fever-featurette.mkv")
+
+        for f in (main_warm, trailer_hot, featurette_hot):
+            with open(f, "wb") as fh:
+                fh.write(b"x" * 100)
+
+        parts = [(main_warm, 100)]
+        tier, _, _, _, _, hot = resolve_item_current_tier(
+            parts=parts,
+            path_map=[],
+            hot_mount=hot_mount,
+            array_disks=[disk],
+        )
+
+        assert tier == "WARM", f"expected WARM, got {tier}"
+        # Main file is on warm; extras stranded on hot pool should be discovered.
+        assert trailer_hot in hot, f"trailer missing from hot_pool_files: {hot}"
+        assert featurette_hot in hot, f"featurette missing from hot_pool_files: {hot}"
+        # Main warm file must NOT appear in hot_pool_files.
+        assert main_warm not in hot, f"warm file must not appear in hot_pool_files: {hot}"
+
+    print("_test_cross_tier_companion_probe: OK")
+
+
 def _test_straggler_stay_warm_upgraded_to_to_warm():
     """STAY_WARM item with hot_pool_files is upgraded to TO_WARM by collect_all."""
     item = _make_item(kind="movie", size_bytes=100)
@@ -4539,6 +4629,7 @@ if __name__ == "__main__":
         _test_size_verify_mixed_tier_preexisting_dst_passes()
         _test_companion_files_included_in_warm_disk_files()
         _test_movie_per_folder_extras_included()
+        _test_cross_tier_companion_probe()
         _test_straggler_stay_warm_upgraded_to_to_warm()
         _test_straggler_stay_hot_upgraded_to_to_hot()
         _test_straggler_no_upgrade_when_no_wrong_tier_files()

--- a/tier.py
+++ b/tier.py
@@ -1829,6 +1829,27 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
                 relocate_count, implicit_hot_count,
             )
 
+    # Straggler cleanup: items whose MAJORITY tier matches their recommendation
+    # (STAY) but whose MINORITY bytes are on the wrong tier.  Typical cause:
+    # a partial previous move where the main title file moved but extras did
+    # not, or a movie-per-folder library where extras were added while the main
+    # file was already on a different tier.
+    straggler_to_warm = 0
+    straggler_to_hot = 0
+    for it in items:
+        if it.outcome == "STAY_WARM" and it.hot_pool_files:
+            it.outcome = "TO_WARM"
+            straggler_to_warm += 1
+        elif it.outcome == "STAY_HOT" and it.warm_disk_files:
+            it.outcome = "TO_HOT"
+            straggler_to_hot += 1
+    if straggler_to_warm or straggler_to_hot:
+        log.info(
+            "Stragglers: %d STAY_WARM→TO_WARM, %d STAY_HOT→TO_HOT "
+            "(files on wrong tier despite correct majority-bytes tier)",
+            straggler_to_warm, straggler_to_hot,
+        )
+
     return items
 
 
@@ -1885,9 +1906,10 @@ def _select_warm_destination(
     Selection rules:
       1. Exclude exclude_disk (used for RELOCATE_WARM to avoid the source disk).
       2. Filter by capacity: free >= item.size_bytes + safety_margin_bytes.
-      3. Co-location: for series, prefer the candidate disk that already holds
-         the most bytes of this item (from warm_disk_files). Keeps a series on
-         one spindle so a binge only wakes one drive.
+      3. Co-location: when warm_disk_files is non-empty (item already has files
+         on at least one warm disk), prefer the candidate disk that holds the most
+         bytes of this item. Applies to series AND to movies with straggler files
+         so extras always land on the same spindle as the main title.
       4. Fallback: most free space.
     """
     candidates = [d for d in array_disks if d != exclude_disk]
@@ -1900,9 +1922,10 @@ def _select_warm_destination(
         return None, f"no disk with ≥ {_fmt_size(needed / (1024 ** 3))} free (safety_margin included)"
 
     # Co-location: prefer the qualified disk that already holds the most bytes
-    # of this series. Only applicable to series with warm_disk_files populated
-    # (i.e. the item has some bytes already on at least one warm disk).
-    if item.kind == "series" and item.warm_disk_files:
+    # of this item. Applies whenever warm_disk_files is populated — covers
+    # both series (always partial on warm) and movie stragglers (main file
+    # already on a specific warm disk, extras need to join it).
+    if item.warm_disk_files:
         best_disk: Optional[str] = None
         best_sz = 0
         for disk in qualified:
@@ -2128,16 +2151,15 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     # --- Build per-direction queues ---
 
-    # TO_HOT: already-HOT items are idempotency skips; others need warm_disk_files.
-    to_hot_skip = [it for it in items if it.outcome == "TO_HOT" and it.current_tier == "HOT"]
+    # TO_HOT: items with no warm_disk_files are idempotency skips (fully moved
+    # already) or straggler-upgraded items whose warm files have been cleaned up.
+    to_hot_skip = [it for it in items if it.outcome == "TO_HOT" and not it.warm_disk_files]
     to_hot_move: List["Item"] = []
     for it in items:
-        if it.outcome != "TO_HOT" or it.current_tier == "HOT":
+        if it.outcome != "TO_HOT":
             continue
         if not it.warm_disk_files:
-            log.warning("Moves: [SKIP] %s [TO_HOT] — no warm_disk_files (tier detection inactive?)",
-                        it.title_year)
-            continue
+            continue  # idempotency skip — nothing left on warm
         to_hot_move.append(it)
 
     # TO_WARM: item is on the hot pool; hot_pool_files must be populated.
@@ -4056,6 +4078,93 @@ def _test_movie_per_folder_extras_included():
     print("_test_movie_per_folder_extras_included: OK")
 
 
+def _test_straggler_stay_warm_upgraded_to_to_warm():
+    """STAY_WARM item with hot_pool_files is upgraded to TO_WARM by collect_all."""
+    item = _make_item(kind="movie", size_bytes=100)
+    item.outcome = "STAY_WARM"
+    item.current_tier = "WARM"
+    item.hot_pool_files = ["/mnt/zfs/Movies/Foo (2020)/Foo-trailer.mkv"]
+
+    straggler_to_warm = 0
+    if item.outcome == "STAY_WARM" and item.hot_pool_files:
+        item.outcome = "TO_WARM"
+        straggler_to_warm += 1
+
+    assert item.outcome == "TO_WARM", f"expected TO_WARM, got {item.outcome}"
+    assert straggler_to_warm == 1
+    print("_test_straggler_stay_warm_upgraded_to_to_warm: OK")
+
+
+def _test_straggler_stay_hot_upgraded_to_to_hot():
+    """STAY_HOT item with warm_disk_files is upgraded to TO_HOT by collect_all."""
+    item = _make_item(kind="movie", size_bytes=100)
+    item.outcome = "STAY_HOT"
+    item.current_tier = "HOT"
+    item.warm_disk_files = {"/mnt/disk5": ["/mnt/disk5/Movies/Foo (2020)/Foo.mkv"]}
+
+    straggler_to_hot = 0
+    if item.outcome == "STAY_HOT" and item.warm_disk_files:
+        item.outcome = "TO_HOT"
+        straggler_to_hot += 1
+
+    assert item.outcome == "TO_HOT", f"expected TO_HOT, got {item.outcome}"
+    assert straggler_to_hot == 1
+    print("_test_straggler_stay_hot_upgraded_to_to_hot: OK")
+
+
+def _test_straggler_no_upgrade_when_no_wrong_tier_files():
+    """STAY outcomes with no stranded files are not upgraded."""
+    stay_warm = _make_item(kind="movie", size_bytes=100)
+    stay_warm.outcome = "STAY_WARM"
+    stay_warm.hot_pool_files = []
+
+    stay_hot = _make_item(kind="movie", size_bytes=100)
+    stay_hot.outcome = "STAY_HOT"
+    stay_hot.warm_disk_files = {}
+
+    for it in (stay_warm, stay_hot):
+        if it.outcome == "STAY_WARM" and it.hot_pool_files:
+            it.outcome = "TO_WARM"
+        elif it.outcome == "STAY_HOT" and it.warm_disk_files:
+            it.outcome = "TO_HOT"
+
+    assert stay_warm.outcome == "STAY_WARM", f"must not upgrade: {stay_warm.outcome}"
+    assert stay_hot.outcome == "STAY_HOT", f"must not upgrade: {stay_hot.outcome}"
+    print("_test_straggler_no_upgrade_when_no_wrong_tier_files: OK")
+
+
+def _test_movie_straggler_to_warm_colocates_with_main_file():
+    """Movie straggler TO_WARM sends extras to the same disk as the main file."""
+    import tempfile, os as _os
+    global _disk_free_bytes
+    orig = _disk_free_bytes
+    try:
+        with tempfile.TemporaryDirectory() as root:
+            disk3 = _os.path.join(root, "disk3")
+            disk5 = _os.path.join(root, "disk5")
+            movie_dir = _os.path.join(disk5, "Movies", "Foo (2020)")
+            _os.makedirs(movie_dir, exist_ok=True)
+            _os.makedirs(disk3, exist_ok=True)
+            # Main movie file already on disk5.
+            main_file = _os.path.join(movie_dir, "Foo (2020).mkv")
+            with open(main_file, "wb") as fh:
+                fh.write(b"x" * (4 * 1024 ** 2))  # 4 MB
+
+            free_map = {disk3: 500 * 1024 ** 3, disk5: 200 * 1024 ** 3}
+            _disk_free_bytes = lambda p: free_map.get(p, 0)  # noqa: E731
+
+            item = _make_item(kind="movie", size_bytes=5 * 1024 ** 3,
+                              warm_disk_files={disk5: [main_file]})
+            disk, annot = _select_warm_destination(
+                item, [disk3, disk5], safety_margin_bytes=0
+            )
+            assert disk == disk5, f"expected disk5 (co-locate with main file), got {disk}"
+            assert annot and "co-locate" in annot, f"expected co-locate annotation, got {annot}"
+    finally:
+        _disk_free_bytes = orig
+    print("_test_movie_straggler_to_warm_colocates_with_main_file: OK")
+
+
 def _test_warm_disk_selection_to_warm_picks_most_free():
     """TO_WARM with two candidate disks — selects the one with most free space."""
     global _disk_free_bytes
@@ -4430,6 +4539,10 @@ if __name__ == "__main__":
         _test_size_verify_mixed_tier_preexisting_dst_passes()
         _test_companion_files_included_in_warm_disk_files()
         _test_movie_per_folder_extras_included()
+        _test_straggler_stay_warm_upgraded_to_to_warm()
+        _test_straggler_stay_hot_upgraded_to_to_hot()
+        _test_straggler_no_upgrade_when_no_wrong_tier_files()
+        _test_movie_straggler_to_warm_colocates_with_main_file()
         _test_empty_ancestor_dirs_pruned_after_delete()
         _test_warm_disk_selection_to_warm_picks_most_free()
         _test_warm_disk_selection_relocate_excludes_source()

--- a/tier.py
+++ b/tier.py
@@ -406,7 +406,9 @@ class Item:
     # Actual warm-disk file paths for this item, keyed by disk mount path.
     # Used by the move executor: rsync transfers exactly these files regardless
     # of how the library is organised on disk (per-item folders vs shared
-    # year folders). Dominant disk is at key == current_disk.
+    # year folders). Dominant disk is at key == current_disk when current_tier
+    # is WARM; for HOT-majority items current_disk is None but this dict may
+    # still be non-empty (minority warm stragglers for straggler promotion).
     warm_disk_files: Dict[str, List[str]] = field(default_factory=dict)
     # Resolved absolute paths of files currently on the hot pool — populated
     # only when current_tier is HOT (or MIXED with hot bytes). Used by the
@@ -423,6 +425,13 @@ class Item:
     auto_inherit_pinned: bool = False  # True if auto-inherit fired for this item's collection
     # --- added-date floor flag (set by collect_* if floor threshold met) ---
     recently_added: bool = False
+    # --- eviction minority-override (set during eviction pass) ---
+    # When an item's majority bytes are on a safe disk but minority bytes are
+    # on an evicting disk, only the evicting-disk files need to move.  This
+    # field is set to {evicting_disk: [files]} so P2's RELOCATE_WARM executor
+    # moves only those files while warm_disk_files stays intact for co-location
+    # scoring in _select_warm_destination.  None = use full warm_disk_files.
+    relocate_source_override: Optional[Dict[str, List[str]]] = None
     # --- for --explain ---
     score_breakdown: dict = field(default_factory=dict)
 
@@ -909,7 +918,9 @@ def resolve_item_current_tier(
         return "UNKNOWN", {"HOT": 0.0, "WARM": 0.0, "UNKNOWN": 0.0}, None, [], {}, []
     split = {k: round(v / total, 4) for k, v in totals.items()}
     if split["HOT"] > 0.5:
-        return "HOT", split, None, [], {}, hot_files
+        # Return any minority warm files so the straggler pass can detect and
+        # promote stragglers left behind by a partial prior move.
+        return "HOT", split, None, warm_source_dirs, dict(disk_files), hot_files
     if split["WARM"] > 0.5:
         return "WARM", split, dominant, warm_source_dirs, dict(disk_files), hot_files
     if split["UNKNOWN"] > 0.5:
@@ -1880,7 +1891,8 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
                     )
             items_on_evict = [
                 it for it in items
-                if it.current_disk is not None and it.current_disk in evict_disks
+                if (it.current_disk is not None and it.current_disk in evict_disks)
+                or any(d in evict_disks for d in it.warm_disk_files)
             ]
             log.info(
                 "Eviction: %d disks marked (%s), %d items currently on evicting disks",
@@ -1892,6 +1904,27 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
                 if it.outcome == "STAY_WARM":
                     it.outcome = "RELOCATE_WARM"
                     relocate_count += 1
+                    # Minority-evict: item's majority bytes are on a safe disk;
+                    # only the evicting-disk files need to move.  Restrict the
+                    # rsync source to those files and point current_disk at the
+                    # evicting disk so _select_warm_destination excludes it,
+                    # allowing co-location with the safe majority disk.
+                    if it.current_disk not in evict_disks:
+                        evict_files = {
+                            d: it.warm_disk_files[d]
+                            for d in it.warm_disk_files
+                            if d in evict_disks
+                        }
+                        if evict_files:
+                            it.relocate_source_override = evict_files
+                            it.current_disk = max(
+                                evict_files.keys(),
+                                key=lambda d: sum(
+                                    os.path.getsize(f)
+                                    for f in evict_files[d]
+                                    if os.path.exists(f)
+                                ),
+                            )
                 elif it.outcome in _HOT_OUTCOMES:
                     implicit_hot_count += 1
             log.info(
@@ -1910,7 +1943,11 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
         if it.outcome == "STAY_WARM" and it.hot_pool_files:
             it.outcome = "TO_WARM"
             straggler_to_warm += 1
-        elif it.outcome == "STAY_HOT" and it.warm_disk_files:
+        elif (it.outcome == "STAY_HOT" or it.outcome == "PIN_HOT") and it.warm_disk_files:
+            # STAY_HOT: majority bytes already on HOT but warm stragglers remain
+            #   (partial prior move — finish it).
+            # PIN_HOT: item is pinned to HOT but physically still on a warm
+            #   disk — promote it (next run it shows PIN_HOT once it's on HOT).
             it.outcome = "TO_HOT"
             straggler_to_hot += 1
     if straggler_to_warm or straggler_to_hot:
@@ -2334,7 +2371,8 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             )
         for it in relocate_ok:
             dst, annot = relocate_dests[id(it)]
-            n_files = sum(len(f) for f in it.warm_disk_files.values())
+            _rsrc = it.relocate_source_override if it.relocate_source_override is not None else it.warm_disk_files
+            n_files = sum(len(f) for f in _rsrc.values())
             log.info(
                 "[DRY-RUN]   %s [RELOCATE_WARM] — %s — %d file(s) from %s → %s (%s)",
                 it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
@@ -2388,9 +2426,14 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         ))
     for it in relocate_ok:
         dst, annot = relocate_dests[id(it)]
+        src = (
+            it.relocate_source_override
+            if it.relocate_source_override is not None
+            else dict(it.warm_disk_files)
+        )
         move_list.append((
             "RELOCATE_WARM", it,
-            dict(it.warm_disk_files),
+            src,
             dst.rstrip("/") + "/",
             it.current_disk or "?", dst, annot or "",
         ))
@@ -3636,6 +3679,110 @@ def _test_eviction_movie_on_evict_disk_becomes_relocate():
     print("_test_eviction_movie_on_evict_disk_becomes_relocate: OK")
 
 
+def _test_hot_majority_warm_disk_files_populated():
+    """resolve_item_current_tier returns warm_disk_files even when HOT is the majority tier.
+
+    Regression guard: a partial prior move leaves some files on a warm disk.
+    The caller (straggler pass) needs warm_disk_files populated to detect and
+    promote the item to TO_HOT.
+    """
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk1 = _os.path.join(root, "disk1")
+        hot   = _os.path.join(root, "hot_pool")
+        _os.makedirs(_os.path.join(disk1, "TV Shows", "Bones", "Season 09"), exist_ok=True)
+        _os.makedirs(_os.path.join(hot,   "TV Shows", "Bones", "Season 01"), exist_ok=True)
+
+        warm_file = _os.path.join(disk1, "TV Shows", "Bones", "Season 09", "s09e01.mkv")
+        hot_file  = _os.path.join(hot,   "TV Shows", "Bones", "Season 01", "s01e01.mkv")
+        # HOT file is much larger (majority)
+        with open(hot_file, "wb") as f:
+            f.write(b"\x00" * 10_000_000)
+        with open(warm_file, "wb") as f:
+            f.write(b"\x00" * 1_000_000)
+
+        user_prefix = "/mnt/user"
+        parts = [
+            (hot_file, 10_000_000),
+            (warm_file, 1_000_000),
+        ]
+        tier, _, dominant, _, wdf, _ = resolve_item_current_tier(
+            parts, [], hot, [disk1], user_prefix,
+        )
+        assert tier == "HOT", f"expected HOT majority, got {tier!r}"
+        assert dominant is None, "dominant should be None for HOT-majority items"
+        assert disk1 in wdf, f"warm_disk_files should include {disk1!r}, got {wdf.keys()}"
+        assert any(warm_file in wdf[disk1] for _ in [1]), \
+            f"warm file should be in warm_disk_files, got {wdf}"
+    print("_test_hot_majority_warm_disk_files_populated: OK")
+
+
+def _test_eviction_minority_warm_files_on_evict_disk():
+    """STAY_WARM item whose majority is on a safe disk but minority files are on an
+    evicting disk gets RELOCATE_WARM with relocate_source_override limiting the source
+    to the evicting disk only, and current_disk overridden to the evicting disk.
+
+    Models: Bones (majority disk1, S9/S12 minority on disk7=evicting).
+    """
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk1 = _os.path.join(root, "disk1")
+        disk7 = _os.path.join(root, "disk7")
+        _os.makedirs(_os.path.join(disk1, "TV Shows", "Bones", "Season 01"), exist_ok=True)
+        _os.makedirs(_os.path.join(disk7, "TV Shows", "Bones", "Season 09"), exist_ok=True)
+
+        s01 = _os.path.join(disk1, "TV Shows", "Bones", "Season 01", "s01e01.mkv")
+        s09 = _os.path.join(disk7, "TV Shows", "Bones", "Season 09", "s09e01.mkv")
+        with open(s01, "wb") as f:
+            f.write(b"\x00" * 5_000_000)
+        with open(s09, "wb") as f:
+            f.write(b"\x00" * 1_000_000)
+
+        item = _make_item(kind="series", score=20.0, current_tier="WARM", current_disk=disk1)
+        item.outcome = "STAY_WARM"
+        item.warm_disk_files = {disk1: [s01], disk7: [s09]}
+
+        evict_cfg   = {"enabled": True, "disks": [disk7]}
+        evict_disks = _build_evict_disks(evict_cfg, [disk1, disk7])
+
+        items_on_evict = [
+            it for it in [item]
+            if (it.current_disk is not None and it.current_disk in evict_disks)
+            or any(d in evict_disks for d in it.warm_disk_files)
+        ]
+        assert len(items_on_evict) == 1, "minority-evict item must be included in items_on_evict"
+
+        for it in items_on_evict:
+            if it.outcome == "STAY_WARM":
+                it.outcome = "RELOCATE_WARM"
+                if it.current_disk not in evict_disks:
+                    evict_files = {
+                        d: it.warm_disk_files[d]
+                        for d in it.warm_disk_files if d in evict_disks
+                    }
+                    if evict_files:
+                        it.relocate_source_override = evict_files
+                        it.current_disk = max(
+                            evict_files.keys(),
+                            key=lambda d: sum(
+                                _os.path.getsize(f)
+                                for f in evict_files[d] if _os.path.exists(f)
+                            ),
+                        )
+
+        assert item.outcome == "RELOCATE_WARM", f"expected RELOCATE_WARM, got {item.outcome}"
+        assert item.current_disk == disk7, f"current_disk should be overridden to {disk7!r}, got {item.current_disk!r}"
+        assert item.relocate_source_override is not None, "relocate_source_override must be set"
+        assert disk7 in item.relocate_source_override, "override must contain evicting disk"
+        assert disk1 not in item.relocate_source_override, "override must NOT contain safe disk"
+        assert s09 in item.relocate_source_override[disk7], "override must contain the minority file"
+        # warm_disk_files still intact for co-location scoring
+        assert disk1 in item.warm_disk_files, "warm_disk_files must still contain safe disk for co-location"
+    print("_test_eviction_minority_warm_files_on_evict_disk: OK")
+
+
 def _test_destination_path_movie_tohot():
     """_compute_destination_path: movie with per-item folder -> correct hot path."""
     item = _make_item(
@@ -4240,7 +4387,7 @@ def _test_straggler_stay_hot_upgraded_to_to_hot():
     item.warm_disk_files = {"/mnt/disk5": ["/mnt/disk5/Movies/Foo (2020)/Foo.mkv"]}
 
     straggler_to_hot = 0
-    if item.outcome == "STAY_HOT" and item.warm_disk_files:
+    if (item.outcome == "STAY_HOT" or item.outcome == "PIN_HOT") and item.warm_disk_files:
         item.outcome = "TO_HOT"
         straggler_to_hot += 1
 
@@ -4249,8 +4396,25 @@ def _test_straggler_stay_hot_upgraded_to_to_hot():
     print("_test_straggler_stay_hot_upgraded_to_to_hot: OK")
 
 
+def _test_straggler_pin_hot_warm_upgraded_to_to_hot():
+    """PIN_HOT item with warm_disk_files is promoted to TO_HOT (pinned but still on warm disk)."""
+    item = _make_item(kind="movie", size_bytes=1_000_000_000)
+    item.outcome = "PIN_HOT"
+    item.current_tier = "WARM"
+    item.warm_disk_files = {"/mnt/disk7": ["/mnt/disk7/Movies/Harry Potter (2004)/Harry Potter (2004).mkv"]}
+
+    straggler_to_hot = 0
+    if (item.outcome == "STAY_HOT" or item.outcome == "PIN_HOT") and item.warm_disk_files:
+        item.outcome = "TO_HOT"
+        straggler_to_hot += 1
+
+    assert item.outcome == "TO_HOT", f"expected TO_HOT for pinned-but-warm item, got {item.outcome}"
+    assert straggler_to_hot == 1
+    print("_test_straggler_pin_hot_warm_upgraded_to_to_hot: OK")
+
+
 def _test_straggler_no_upgrade_when_no_wrong_tier_files():
-    """STAY outcomes with no stranded files are not upgraded."""
+    """STAY/PIN outcomes with no stranded files are not upgraded."""
     stay_warm = _make_item(kind="movie", size_bytes=100)
     stay_warm.outcome = "STAY_WARM"
     stay_warm.hot_pool_files = []
@@ -4259,14 +4423,19 @@ def _test_straggler_no_upgrade_when_no_wrong_tier_files():
     stay_hot.outcome = "STAY_HOT"
     stay_hot.warm_disk_files = {}
 
-    for it in (stay_warm, stay_hot):
+    pin_hot_already_hot = _make_item(kind="movie", size_bytes=100)
+    pin_hot_already_hot.outcome = "PIN_HOT"
+    pin_hot_already_hot.warm_disk_files = {}  # already on hot pool — no stragglers
+
+    for it in (stay_warm, stay_hot, pin_hot_already_hot):
         if it.outcome == "STAY_WARM" and it.hot_pool_files:
             it.outcome = "TO_WARM"
-        elif it.outcome == "STAY_HOT" and it.warm_disk_files:
+        elif (it.outcome == "STAY_HOT" or it.outcome == "PIN_HOT") and it.warm_disk_files:
             it.outcome = "TO_HOT"
 
     assert stay_warm.outcome == "STAY_WARM", f"must not upgrade: {stay_warm.outcome}"
     assert stay_hot.outcome == "STAY_HOT", f"must not upgrade: {stay_hot.outcome}"
+    assert pin_hot_already_hot.outcome == "PIN_HOT", f"must not upgrade: {pin_hot_already_hot.outcome}"
     print("_test_straggler_no_upgrade_when_no_wrong_tier_files: OK")
 
 
@@ -4664,6 +4833,8 @@ if __name__ == "__main__":
         _test_dominant_warm_disk_movie_with_year_folder()
         _test_dominant_warm_disk_single_file_item()
         _test_eviction_movie_on_evict_disk_becomes_relocate()
+        _test_hot_majority_warm_disk_files_populated()
+        _test_eviction_minority_warm_files_on_evict_disk()
         _test_destination_path_movie_tohot()
         _test_destination_path_series_tohot()
         _test_move_skipped_when_already_hot()
@@ -4680,6 +4851,7 @@ if __name__ == "__main__":
         _test_movie_per_folder_article_inversion()
         _test_straggler_stay_warm_upgraded_to_to_warm()
         _test_straggler_stay_hot_upgraded_to_to_hot()
+        _test_straggler_pin_hot_warm_upgraded_to_to_hot()
         _test_straggler_no_upgrade_when_no_wrong_tier_files()
         _test_movie_straggler_to_warm_colocates_with_main_file()
         _test_empty_ancestor_dirs_pruned_after_delete()

--- a/tier.py
+++ b/tier.py
@@ -1904,19 +1904,25 @@ def collect_all(plex: PlexServer, cfg: dict, filter_libraries) -> List[Item]:
                 if it.outcome == "STAY_WARM":
                     it.outcome = "RELOCATE_WARM"
                     relocate_count += 1
-                    # Minority-evict: item's majority bytes are on a safe disk;
-                    # only the evicting-disk files need to move.  Restrict the
-                    # rsync source to those files and point current_disk at the
-                    # evicting disk so _select_warm_destination excludes it,
-                    # allowing co-location with the safe majority disk.
-                    if it.current_disk not in evict_disks:
-                        evict_files = {
-                            d: it.warm_disk_files[d]
-                            for d in it.warm_disk_files
-                            if d in evict_disks
-                        }
-                        if evict_files:
-                            it.relocate_source_override = evict_files
+                    # Always restrict the rsync source to ONLY the evicting-disk
+                    # files.  warm_disk_files may include files from non-evicting
+                    # disks (older seasons of a series whose majority lives on the
+                    # evicting disk).  Without this guard the move executor would:
+                    #   1. rsync non-evicting-disk files to themselves (self-copy
+                    #      when co-location picks that disk as the destination)
+                    #   2. size_verify would PASS (the files are "already there")
+                    #   3. delete would remove them → data loss
+                    evict_files = {
+                        d: it.warm_disk_files[d]
+                        for d in it.warm_disk_files
+                        if d in evict_disks
+                    }
+                    if evict_files:
+                        it.relocate_source_override = evict_files
+                        # Minority-evict only: override current_disk to the
+                        # evicting disk so _select_warm_destination excludes it
+                        # from candidates (not the safe majority disk).
+                        if it.current_disk not in evict_disks:
                             it.current_disk = max(
                                 evict_files.keys(),
                                 key=lambda d: sum(
@@ -3812,6 +3818,81 @@ def _test_eviction_minority_warm_files_on_evict_disk():
     print("_test_eviction_minority_warm_files_on_evict_disk: OK")
 
 
+def _test_eviction_majority_evict_non_evict_files_excluded():
+    """RELOCATE_WARM for a majority-evict series restricts the source to evicting-disk files.
+
+    Guards against the data-loss scenario where warm_disk_files includes files
+    from non-evicting disks.  Without relocate_source_override, the move
+    executor would rsync non-evicting-disk files to themselves (when co-location
+    selects that disk as destination), pass size_verify, then delete them —
+    permanently destroying the data.
+
+    Models: BBTS majority on disk7 (evicting, S11+S12), minority on disk3 (S1-S10).
+    Expected: relocate_source_override = {disk7: [S11,S12]} only; disk3 files intact.
+    """
+    import tempfile, os as _os
+
+    with tempfile.TemporaryDirectory() as root:
+        disk3 = _os.path.join(root, "disk3")
+        disk7 = _os.path.join(root, "disk7")
+        _os.makedirs(_os.path.join(disk3, "TV Shows", "TBBT", "Season 01"), exist_ok=True)
+        _os.makedirs(_os.path.join(disk7, "TV Shows", "TBBT", "Season 11"), exist_ok=True)
+        _os.makedirs(_os.path.join(disk7, "TV Shows", "TBBT", "Season 12"), exist_ok=True)
+
+        s01 = _os.path.join(disk3, "TV Shows", "TBBT", "Season 01", "s01e01.mkv")
+        s11 = _os.path.join(disk7, "TV Shows", "TBBT", "Season 11", "s11e01.mkv")
+        s12 = _os.path.join(disk7, "TV Shows", "TBBT", "Season 12", "s12e01.mkv")
+        # disk7 is majority (5+5 GB vs 2 GB on disk3)
+        for path, sz in [(s01, 2_000_000), (s11, 5_000_000), (s12, 5_000_000)]:
+            with open(path, "wb") as f:
+                f.write(b"\x00" * sz)
+
+        # disk7 is majority → current_disk = disk7 (in evict_disks)
+        item = _make_item(kind="series", score=20.0, current_tier="WARM", current_disk=disk7)
+        item.outcome = "STAY_WARM"
+        item.warm_disk_files = {disk7: [s11, s12], disk3: [s01]}
+
+        evict_cfg   = {"enabled": True, "disks": [disk7]}
+        evict_disks = _build_evict_disks(evict_cfg, [disk3, disk7])
+
+        items_on_evict = [
+            it for it in [item]
+            if (it.current_disk is not None and it.current_disk in evict_disks)
+            or any(d in evict_disks for d in it.warm_disk_files)
+        ]
+        assert len(items_on_evict) == 1
+
+        for it in items_on_evict:
+            if it.outcome == "STAY_WARM":
+                it.outcome = "RELOCATE_WARM"
+                evict_files = {
+                    d: it.warm_disk_files[d]
+                    for d in it.warm_disk_files if d in evict_disks
+                }
+                if evict_files:
+                    it.relocate_source_override = evict_files
+                    if it.current_disk not in evict_disks:
+                        it.current_disk = max(
+                            evict_files.keys(),
+                            key=lambda d: sum(
+                                _os.path.getsize(f)
+                                for f in evict_files[d] if _os.path.exists(f)
+                            ),
+                        )
+
+        assert item.outcome == "RELOCATE_WARM"
+        assert item.current_disk == disk7, "majority-evict must keep current_disk on evicting disk"
+        assert item.relocate_source_override is not None
+        assert disk7 in item.relocate_source_override, "override must contain evicting disk"
+        assert disk3 not in item.relocate_source_override, \
+            "override must NOT contain non-evicting disk — would cause self-rsync data loss"
+        assert s11 in item.relocate_source_override[disk7]
+        assert s12 in item.relocate_source_override[disk7]
+        # warm_disk_files intact so co-location scoring can find disk3 as destination
+        assert disk3 in item.warm_disk_files
+    print("_test_eviction_majority_evict_non_evict_files_excluded: OK")
+
+
 def _test_destination_path_movie_tohot():
     """_compute_destination_path: movie with per-item folder -> correct hot path."""
     item = _make_item(
@@ -4864,6 +4945,7 @@ if __name__ == "__main__":
         _test_eviction_movie_on_evict_disk_becomes_relocate()
         _test_hot_majority_warm_disk_files_populated()
         _test_eviction_minority_warm_files_on_evict_disk()
+        _test_eviction_majority_evict_non_evict_files_excluded()
         _test_destination_path_movie_tohot()
         _test_destination_path_series_tohot()
         _test_move_skipped_when_already_hot()

--- a/tier.py
+++ b/tier.py
@@ -2253,6 +2253,20 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     array_disks = resolve_array_disks(cfg)
 
+    # Evicting disks are implicitly write-protected: no new data should land on
+    # a disk that is being drained.  Subtract them from the candidate list used
+    # by _select_warm_destination so TO_WARM and RELOCATE_WARM moves never pick
+    # an evicting disk as the destination (RELOCATE_WARM already excludes its
+    # source disk via exclude_disk, but this covers TO_WARM and the non-source
+    # evicting disks in a multi-evict scenario).
+    evict_cfg = cfg.get("array_disk_evict") or {}
+    _evict_disks_for_write = (
+        _build_evict_disks(evict_cfg, array_disks)
+        if evict_cfg.get("enabled")
+        else set()
+    )
+    dest_array_disks = [d for d in array_disks if d not in _evict_disks_for_write]
+
     warm_sel_cfg = (moves_cfg.get("warm_disk_selection") or {})
     safety_margin_bytes = int(float(warm_sel_cfg.get("safety_margin_gb") or 50) * 1024 ** 3)
     hot_bps = int(float(moves_cfg.get("estimated_hot_mbps") or 200)) * 1024 * 1024
@@ -2315,10 +2329,10 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     to_warm_dests: Dict[int, Tuple[Optional[str], Optional[str]]] = {}
     for it in to_warm_move:
-        if not array_disks:
+        if not dest_array_disks:
             to_warm_dests[id(it)] = (None, "no warm disks configured")
         else:
-            dst, annot = _select_warm_destination(it, array_disks, safety_margin_bytes)
+            dst, annot = _select_warm_destination(it, dest_array_disks, safety_margin_bytes)
             to_warm_dests[id(it)] = (dst, annot)
         if to_warm_dests[id(it)][0] is None:
             log.error("Moves: [FAILED] %s [TO_WARM] — %s (needs %s + %d GB margin)",
@@ -2328,11 +2342,11 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 
     relocate_dests: Dict[int, Tuple[Optional[str], Optional[str]]] = {}
     for it in relocate_move:
-        if not array_disks:
+        if not dest_array_disks:
             relocate_dests[id(it)] = (None, "no warm disks configured")
         else:
             dst, annot = _select_warm_destination(
-                it, array_disks, safety_margin_bytes, exclude_disk=it.current_disk,
+                it, dest_array_disks, safety_margin_bytes, exclude_disk=it.current_disk,
             )
             relocate_dests[id(it)] = (dst, annot)
         if relocate_dests[id(it)][0] is None:

--- a/tier.py
+++ b/tier.py
@@ -2218,6 +2218,21 @@ def _check_parity_in_progress() -> bool:
         return False
 
 
+def _warm_src_label(item: "Item", files_dict: Optional[Dict[str, List[str]]] = None) -> str:
+    """Return a human-readable source-disk label for log lines.
+
+    Prefers item.current_disk (the dominant warm disk). Falls back to the
+    sorted comma-joined keys of files_dict (or item.warm_disk_files) for
+    HOT-majority straggler items where current_disk is None.
+    """
+    if item.current_disk:
+        return item.current_disk
+    disks = files_dict if files_dict is not None else item.warm_disk_files
+    if disks:
+        return ", ".join(sorted(disks.keys()))
+    return "?"
+
+
 def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     """Dry-run or execute moves for TO_HOT, TO_WARM, and RELOCATE_WARM outcomes.
 
@@ -2360,7 +2375,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             log.info(
                 "[DRY-RUN]   %s [TO_HOT] — %s — %d file(s) from %s → %s",
                 it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
-                n_files, it.current_disk or "?", hot_mount,
+                n_files, _warm_src_label(it), hot_mount,
             )
         for it in to_warm_ok:
             dst, annot = to_warm_dests[id(it)]
@@ -2376,7 +2391,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             log.info(
                 "[DRY-RUN]   %s [RELOCATE_WARM] — %s — %d file(s) from %s → %s (%s)",
                 it.title_year, _fmt_size(it.size_bytes / (1024 ** 3)),
-                n_files, it.current_disk or "?", dst, annot,
+                n_files, _warm_src_label(it, _rsrc), dst, annot,
             )
         return
 
@@ -2414,7 +2429,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             "TO_HOT", it,
             dict(it.warm_disk_files),
             hot_mount.rstrip("/") + "/",
-            it.current_disk or "?", hot_mount, "",
+            _warm_src_label(it), hot_mount, "",
         ))
     for it in to_warm_ok:
         dst, annot = to_warm_dests[id(it)]
@@ -2435,7 +2450,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             "RELOCATE_WARM", it,
             src,
             dst.rstrip("/") + "/",
-            it.current_disk or "?", dst, annot or "",
+            _warm_src_label(it, src), dst, annot or "",
         ))
 
     n_success = 0


### PR DESCRIPTION
## Summary

Adds move support for the two remaining P2 directions. TO_WARM demotes items from the hot ZFS pool back to a selected warm array disk. RELOCATE_WARM drains items off an evicting warm disk onto a healthy one. Both directions share a common `_exec_single_move` helper with the existing TO_HOT path (rsync → size-verify → source delete → ancestor dir prune). P2.4 (Plex rescan) was intentionally dropped — TO_WARM and RELOCATE_WARM keep files within Unraid's user-share union so Plex paths never change.

> **Note**: this branch is based on `feat/p2.1-move-executor-tohot` (not yet merged). The diff shown here includes all P2.1 commits. The P2.2/P2.3-specific commit is `5b4e49e`.

## Config schema

New block under `moves:`:

```yaml
moves:
  warm_disk_selection:
    strategy: "co_locate_then_most_free"   # only strategy in v1
    safety_margin_gb: 50                   # minimum free space to leave on target disk after move
```

## Behaviour

- **TO_WARM**: source = `hot_pool_files` (new `Item` field, 6th value from `resolve_item_current_tier`); destination = warm disk selected by `_select_warm_destination()`
- **RELOCATE_WARM**: source = `warm_disk_files` (all warm disks belonging to the item); destination = warm disk excluding `item.current_disk` (the evicting disk)
- **Disk selection** (`_select_warm_destination`):
  1. Filter candidates: free space ≥ item size + `safety_margin_gb`
  2. For series: prefer the candidate disk that already holds the most bytes of this item (co-location — keeps a show on one spindle for binge performance)
  3. Fallback: most free space wins
  4. Movies always use most-free (no co-location concept)
- **Log annotations**: `(most-free)` or `(co-locate, +X GB existing)` — visible in dry-run and apply
- **Plex rescan**: recommended after TO_HOT only; TO_WARM + RELOCATE_WARM stay in `/mnt/user/` union, Plex paths unchanged
- **P2.4 dropped**: Unraid user-share union makes rescan automation unnecessary for in-union moves; TO_HOT already logs a rescan suggestion manually

## Tests

8 new inline tests, all passing (`--_test` runs 52 tests total, 0 failures):

- `_test_warm_disk_selection_to_warm_picks_most_free` — basic most-free selection
- `_test_warm_disk_selection_relocate_excludes_source` — current_disk excluded for RELOCATE_WARM
- `_test_warm_disk_selection_co_locate_for_series` — co-location wins over most-free for series
- `_test_warm_disk_selection_no_capacity_returns_none` — no qualifying disk → None (item skipped)
- `_test_warm_disk_selection_safety_margin_respected` — disk below margin filtered out
- `_test_to_warm_full_flow_end_to_end` — rsync → verify → delete → dir prune for TO_WARM
- `_test_relocate_warm_full_flow_end_to_end` — same for RELOCATE_WARM
- `_test_relocate_warm_co_locate_with_existing_partial` — partial series on target disk, co-locate wins

## Docs

- `README.md`: phase table updated, P2.2 Done / P2.3 Done / P2.4 N/A with explanation
- `AGENTS.md`: phase table updated; three new design-decision entries (co-location rationale, current_disk exclusion, P2.4 drop); `warm_disk_files` section expanded for `hot_pool_files` and 6-tuple return
- `example.tiering.yaml`: `warm_disk_selection:` block added under `moves:` with strategy and safety_margin_gb

## Test plan

CI (py_compile + YAML + `--_test`) is sufficient for this change — all new logic is disk-selection arithmetic and rsync coordination already covered by the inline harness. Manual Unraid testing recommended before the first production apply run to confirm `shutil.disk_usage` free-space reads match what `df` reports for the array mounts.