### PR TITLE
feat(P3): capacity-aware tiering — hot pool ceiling + promotion budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -759,8 +759,10 @@ by the refdbytes issue; `free` is not.
    `--volume /proc/spl:/proc/spl:ro` to container extra parameters.
 4. `hot_pool_total_gb` config override — `total = cfg_gb × 1024³`,
    `used = total − statvfs.free`. Requires one-time YAML config entry. To find
-   the value, run on the Unraid host (replace mount and pool name as needed):
-   `zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'`
+   the value, run on the Unraid host (replace pool name as needed). Use `zfs get`
+   (dataset layer, accounts for RAIDZ parity) — `zpool list` size/alloc/free are
+   raw vdev bytes and do NOT reflect parity overhead:
+   `zfs get -Hp -o value available,used Zfs_media | awk '{s+=$1} END {printf "%d\n", s/1024/1024/1024}'`
 5. `statvfs` fallback — logs a WARNING when `used=0` so operators know to
    configure one of the above options.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -709,6 +709,64 @@ from firing during a run where you want to inspect outcomes before committing
 to changes. Both are logged explicitly in the Capacity: output so dry-run
 output is unambiguous about why items are deferred or not demoted.
 
+**ZFS hot pool usage: why statvfs fails inside Docker, and the fallback chain.**
+
+ZFS exposes pool stats via `statvfs` as follows (on the root dataset):
+- `used`  = `refdbytes` — bytes stored **directly** in the root dataset only.
+- `total` = `refdbytes + availbytes` — NOT pool total; roughly equals pool free.
+
+When all media files live in child datasets (e.g. `Zfs_media/Movies`), the
+root dataset's `refdbytes` is 0, so `used = 0` and `total ≈ pool free`. This
+makes `shutil.disk_usage` return nonsense (`0% full, total ≈ 35 TB` when the
+pool is actually `39% full, total = 63.8 TB`).
+
+Options considered and why they were rejected or accepted:
+
+| Method | Accurate | Works in Docker | Dependencies | Notes |
+|---|---|---|---|---|
+| `statvfs` (plain) | ✗ ZFS child datasets | Yes | None | Fallback only; WARNING emitted when `used=0` |
+| `du` recursive | ✗ logical, not on-disk | Yes (slow) | None | Metadata-heavy; ignores compression ratio |
+| ZFS tools in image | ✓ | Yes | zfsutils-linux | Image bloat, version mismatch, security surface |
+| `/dev/zfs` passthrough | ✓ | Yes | Privileged mount | Significant security risk; rejected |
+| `/proc/spl` bind-mount | ✓ | Yes (if mounted) | Docker config change | No ZFS tools needed; clean read-only kernel stats |
+| Unraid GraphQL API | ✓ | Yes | Unraid 6.12+, auth | Unraid-specific; complex auth setup |
+| `hot_pool_total_gb` config | ✓ (with statvfs free) | Yes | Manual config | Simple, no deps; requires one-time config; update when pool grows |
+
+**Why `statvfs.free` is reliable even when `used` is wrong.**
+ZFS statvfs does report `f_bavail` (available bytes for new writes) correctly —
+it reflects the actual pool free space. So `used = configured_total - statvfs_free`
+is accurate when `hot_pool_total_gb` is set. Only `total` and `used` are broken
+by the refdbytes issue; `free` is not.
+
+**The implemented priority chain** (`_pool_usage_bytes`):
+
+1. `_try_unraid_api(url, key, pool_name_filter)` — POST GraphQL to the Unraid
+   Connect API (`capacity.unraid_api_url` + `capacity.unraid_api_key`). Matches
+   on `capacity.unraid_pool_name` if set; otherwise uses the first ZFS pool
+   whose total ≥ `statvfs.free` as a size-floor heuristic. Requires Unraid
+   6.12+ and an API key (Settings → Management Access → API Keys).
+2. `_try_zpool_cmd(pool_name)` — runs `zpool list -Hp -o size,alloc`. Works if
+   ZFS userspace tools are present in the container. Pool name extracted from
+   `/proc/mounts` via `_zfs_pool_name_for_mount`.
+3. `_try_zpool_kstat(pool_name)` — reads `/proc/spl/kstat/zfs/<pool>/objset-*`.
+   Kernel module exposes these host-globally, but Docker containers have an
+   isolated `/proc` namespace. Works only if the user adds
+   `--volume /proc/spl:/proc/spl:ro` to container extra parameters.
+4. `hot_pool_total_gb` config override — `total = cfg_gb × 1024³`,
+   `used = total − statvfs.free`. Requires one-time YAML config entry. To find
+   the value, run on the Unraid host (replace mount and pool name as needed):
+   `zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'`
+5. `statvfs` fallback — logs a WARNING when `used=0` so operators know to
+   configure one of the above options.
+
+**Per-disk warm capacity log.** The warm disk section now logs one INFO line per
+disk (via `shutil.disk_usage`, which is correct for spinning-disk ext4/xfs):
+```
+Capacity: warm disk /mnt/disk1 — 4.2 / 8.0 TB (53%)
+Capacity: warm disk /mnt/disk2 — 7.6 / 8.0 TB (95%)  ← over 90% ceiling
+```
+This replaces the previous "warm disks all under N% ceiling" summary line.
+
 ## Development rules
 
 ### Write only to `/config` at runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ CLAUDE.md and GEMINI.md are symlinks to this file.
 | P2.2 | TO_WARM moves — demote from hot pool to chosen warm disk; co_locate_then_most_free destination selection | Done |
 | P2.3 | RELOCATE_WARM moves — drain evicting warm disks to healthy warm disks; source disk excluded from candidates | Done |
 | P2.4 | Plex rescan automation — dropped (Unraid user-share union makes it unnecessary for in-union moves) | N/A |
-| P3   | Hardening: lock file, currently-playing skip, free-space check, move cap | Pending |
+| P3   | Capacity-aware tiering — hot pool ceiling + promotion budget (OVER_BUDGET_HOT), optional auto-demote, warm per-disk ceiling, --no-promote / --no-demote | Done |
 | P4   | Scheduled cron + size-triggered wrapper | Pending |
 
 ## Non-obvious design decisions
@@ -653,6 +653,61 @@ example:
 
 `DEFAULT_CONFIG` in `tier.py` is the source of truth for defaults and
 merges over the user config via `_deep_merge()`. Keep the two in sync.
+
+### Capacity-aware tiering (P3)
+
+`_apply_capacity_budget()` runs after `collect_all()` and before
+`_run_move_pass()` in `_run()`. It modifies item outcomes in-place so
+the move pass sees budget-adjusted queues.
+
+**Why `OVER_BUDGET_HOT` is its own outcome rather than overloading `STAY_WARM`.**
+An item assigned `OVER_BUDGET_HOT` scored high enough for HOT — it is being
+denied promotion this run purely because the pool has no room, not because its
+score dropped. Overloading `STAY_WARM` would lose that signal: operators need
+to be able to tell "this item is correctly warm" from "this item deserves HOT
+but the pool is full today". Using a distinct outcome also lets P2's move pass
+skip the item without special-casing (it's not in the TO_HOT queue) while the
+output table and summary still flag it clearly. The outcome is counted in
+`_WARM_OUTCOMES` so projected-WARM totals include items that will stay warm due
+to budget constraints.
+
+**Why `PIN_HOT` is exempt from auto-demote.**
+Auto-demote converts lowest-scoring `STAY_HOT` items to `TO_WARM` until the
+pool comes under the ceiling. `PIN_HOT` items (library-pinned, title-pinned,
+collection-pinned) reflect *explicit operator intent* — the user said "keep
+this on HOT regardless of score". Demoting them automatically would silently
+violate that intent, likely causing the item to be re-promoted next run (score
+is irrelevant for pins), creating a flip-flop loop. Only `STAY_HOT` items —
+those on HOT by score alone — are candidates.
+
+**Why pool-level ceilings and per-disk warm ceilings are separate knobs.**
+They guard against different failure modes:
+
+- `hot_ceiling_percent`: ZFS pool write-amplification and snapshot space.
+  Filling a ZFS pool past ~80% degrades performance and can starve snapshot
+  reservations. This is a pool-level property; individual vdevs don't matter.
+- `warm_per_disk_ceiling_percent`: Unraid array spindle health. An individual
+  spinning disk near 100% fill has higher fragmentation, slower seek times, and
+  leaves no room for Plex to write sidecar files. This is a per-disk property;
+  the pool-level ceiling is irrelevant. Enforced in `_select_warm_destination`
+  so any destination disk over the ceiling is excluded from candidates.
+
+**Why budget is computed against the ceiling, not against 100%.**
+Computing `budget = total - used - margin` (against 100%) would allow the pool
+to be filled right up to full, defeating the purpose of `hot_ceiling_percent`.
+Computing against the ceiling — `budget = ceiling_bytes - used - margin` —
+means the budget tracks remaining capacity *within the headroom policy*, which
+is what operators want. If the pool is already above the ceiling (e.g. was
+nearly full before this feature was added), the budget is clamped to zero,
+blocking all promotions until space is freed.
+
+**`--no-promote` and `--no-demote` CLI flags.**
+Both are one-shot overrides: they don't change config, only this run.
+`--no-promote` is useful for maintenance windows or when the operator wants
+to let the pool drain without new inflows. `--no-demote` prevents auto-demote
+from firing during a run where you want to inspect outcomes before committing
+to changes. Both are logged explicitly in the Capacity: output so dry-run
+output is unambiguous about why items are deferred or not demoted.
 
 ## Development rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,11 +740,16 @@ by the refdbytes issue; `free` is not.
 
 **The implemented priority chain** (`_pool_usage_bytes`):
 
-1. `_try_unraid_api(url, key, pool_name_filter)` — POST GraphQL to the Unraid
-   Connect API (`capacity.unraid_api_url` + `capacity.unraid_api_key`). Matches
-   on `capacity.unraid_pool_name` if set; otherwise uses the first ZFS pool
-   whose total ≥ `statvfs.free` as a size-floor heuristic. Requires Unraid
-   6.12+ and an API key (Settings → Management Access → API Keys).
+1. `_try_unraid_api(url, key, pool_name_filter, hot_mount)` — POST GraphQL to
+   the Unraid Connect API (`capacity.unraid_api_url` + `capacity.unraid_api_key`).
+   ZFS pools are modelled as cache entries in Unraid's array API; the correct
+   query is `{ array { caches { name fsType fsSize fsFree fsUsed } } }` (not a
+   `pools` top-level field — that does not exist in the schema). Match priority:
+   (a) `capacity.unraid_pool_name` exact match; (b) last path component of
+   `hot_pool_mount` (e.g. `/mnt/zfs_media` → `zfs_media`); (c) first ZFS
+   cache whose `fsSize ≥ statvfs.free`. Requires Unraid 6.12+ and an API key
+   (Settings → Management Access → API Keys). HTTPS required; use
+   `https://` in `unraid_api_url` — nginx redirects HTTP with a 302.
 2. `_try_zpool_cmd(pool_name)` — runs `zpool list -Hp -o size,alloc`. Works if
    ZFS userspace tools are present in the container. Pool name extracted from
    `/proc/mounts` via `_zfs_pool_name_for_mount`.

--- a/README.md
+++ b/README.md
@@ -759,12 +759,16 @@ commands below derive the pool name directly from your `hot_pool_mount` path:
 # Step 1 — find the ZFS pool name from the mount point:
 awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts
 
-# Step 2 — get pool size in GB (replace Zfs_media with the name from step 1):
-zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'
+# Step 2 — get USABLE pool size in GiB (accounts for RAIDZ parity overhead).
+# Uses 'zfs get' (ZFS dataset layer) not 'zpool list' — zpool's size/alloc/free
+# are raw vdev bytes and do not reflect parity overhead.
+# Replace Zfs_media with the name from step 1:
+zfs get -Hp -o value available,used Zfs_media | awk '{s+=$1} END {printf "%d\n", s/1024/1024/1024}'
 
 # Or as a single combined command:
 POOL=$(awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts) \
-  && zpool list -Hp -o size $POOL | awk -v p="$POOL" '{printf "%d GB (%s)\n", $1/1024/1024/1024, p}'
+  && zfs get -Hp -o value available,used $POOL \
+  | awk -v p="$POOL" '{s+=$1} END {printf "%d (%s)\n", s/1024/1024/1024, p}'
 ```
 
 Then set in `tiering.yaml`:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ execute; default is dry-run.
 | P2.2 | TO_WARM moves — demote items from hot pool to chosen warm disk (co-location + most-free selection). | **Done** |
 | P2.3 | RELOCATE_WARM moves — drain evicting warm disks to healthy warm disks. Evicting disk excluded from candidates. | **Done** |
 | P2.4 | Plex rescan automation — **intentionally not implemented**. Unraid's user-share union means Plex always reads through `/mnt/user/` regardless of which physical disk backs a file; TO_WARM and RELOCATE_WARM moves are invisible to Plex at the path level. Only TO_HOT (which moves files off the union to a separate ZFS mount) recommends a rescan. | N/A |
-| P3 | Hardened safeguards (lock file, currently-playing skip, free-space check, move-size cap). | Pending |
+| P3 | Capacity-aware tiering — hot pool fill ceiling, promotion budget, `OVER_BUDGET_HOT` outcome, optional auto-demote of lowest-scoring HOT items, warm per-disk ceiling, `--no-promote` / `--no-demote` flags. | **Done** |
 | P4 | Scheduled cron + size-triggered wrapper. | Pending |
 
 ## Install
@@ -310,6 +310,7 @@ Outcomes:
 | `NEUTRAL` | In the score dead zone AND tier detection disabled. |
 | `MIXED_NEUTRAL` | Files are split exactly 50/50 across tiers with no score-based direction to resolve it. P2 leaves it alone. Very rare. |
 | `RELOCATE_WARM` | On a WARM disk marked for eviction. Score says keep warm, but P2 must move to a different warm disk. See [Disk eviction](#disk-eviction) below. |
+| `OVER_BUDGET_HOT` | Scored high enough for HOT but the hot pool budget was exhausted (or `--no-promote` was set). Item stays warm this run. Counted in projected WARM totals. |
 
 Tier detection activates automatically when `paths.hot_pool_mount` is set AND
 at least one array disk is known (either listed explicitly in `paths.array_disks`
@@ -708,6 +709,84 @@ Passes `--bwlimit` to rsync. `null` (default) = unthrottled.
    item. Confirm the destination has the file and the source still exists.
 3. After watching a few successful apply runs, set
    `delete_source_after_verify: true`.
+
+## Capacity-aware tiering (P3)
+
+The capacity layer sits between scoring and the move executor. It enforces a
+fill ceiling on the hot ZFS pool and, optionally, demotes the lowest-scoring
+items when the pool is already over that ceiling.
+
+### Hot pool ceiling and promotion budget
+
+```yaml
+capacity:
+  hot_ceiling_percent: 80        # refuse to fill ZFS pool past this
+  budget_safety_margin_gb: 0     # additional headroom inside the ceiling
+```
+
+Every run, `tier.py` reads the current pool usage and computes:
+
+```
+budget = (hot_ceiling_percent / 100 × pool_total) - pool_used - safety_margin_gb
+```
+
+`TO_HOT` candidates are then sorted by score (highest first) and allocated
+against the budget in order. Items that fit keep their `TO_HOT` outcome; items
+that don't fit get the outcome **`OVER_BUDGET_HOT`** — they stay warm this run
+and try again next time as scores evolve. If the budget is zero or negative,
+all `TO_HOT` items are deferred.
+
+The Capacity section of the log (before the move table) shows the full
+accounting:
+
+```
+Capacity: hot pool 67% full (10.2 / 15.0 TB) — budget 1.8 TB to 80% ceiling
+Capacity: 47 TO_HOT candidates totalling 3.4 TB — fitting 24 within budget, 23 deferred (OVER_BUDGET_HOT)
+Capacity: warm disks all under 90% ceiling
+```
+
+### Warm disk ceiling
+
+```yaml
+capacity:
+  warm_per_disk_ceiling_percent: 90   # skip warm disks above this fill level
+```
+
+When selecting a destination disk for `TO_WARM` or `RELOCATE_WARM` moves,
+disks already at or above `warm_per_disk_ceiling_percent` are excluded from
+candidates. If no qualifying disk remains, the item is logged as `[FAILED]` and
+left in place until space frees up on a warm disk.
+
+### Auto-demote when over ceiling
+
+```yaml
+capacity:
+  auto_demote_when_over_ceiling: false   # set true to enable
+```
+
+When `true` and the hot pool is **already over the ceiling** at run start,
+`tier.py` forces the lowest-scoring `STAY_HOT` items to `TO_WARM` — one by one
+in ascending score order — until the pool would come back under the ceiling.
+`PIN_HOT` items (library/title/collection pins) are always exempt; only items on
+HOT by score alone are candidates.
+
+The auto-demote block appears in the log before the move table:
+
+```
+Capacity: hot pool 84% full — over 80% ceiling, demoting lowest scorers
+Capacity: demoted 12 items (520 GB) to TO_WARM to bring pool to 79.6%
+```
+
+### CLI direction flags
+
+| Flag | Effect |
+|---|---|
+| `--no-promote` | Defers all `TO_HOT` items to `OVER_BUDGET_HOT` regardless of budget |
+| `--no-demote` | Skips the auto-demote pass even when the pool is over ceiling |
+
+Both flags are one-shot per-run overrides. They don't change `tiering.yaml`.
+Each is logged explicitly so dry-run output is unambiguous about why items are
+deferred or not demoted.
 
 ## Tuning
 

--- a/README.md
+++ b/README.md
@@ -716,6 +716,68 @@ The capacity layer sits between scoring and the move executor. It enforces a
 fill ceiling on the hot ZFS pool and, optionally, demotes the lowest-scoring
 items when the pool is already over that ceiling.
 
+### Hot pool usage detection (ZFS)
+
+`tier.py` tries five methods in order to read hot pool usage, stopping at the
+first that succeeds:
+
+| Priority | Method | When it works |
+|---|---|---|
+| 1 | Unraid Connect GraphQL API | `unraid_api_url` + `unraid_api_key` configured |
+| 2 | `zpool list` command | ZFS userspace tools installed in the container |
+| 3 | `/proc/spl` kernel stats | `/proc/spl` bind-mounted from the Unraid host |
+| 4 | `hot_pool_total_gb` config key | You set the pool size manually in `tiering.yaml` |
+| 5 | `statvfs` fallback | Non-ZFS filesystems; **unreliable for ZFS** (see below) |
+
+**Why `statvfs` is unreliable for ZFS:** When all media files live in ZFS child
+datasets (e.g. `Zfs_media/Movies`), the root dataset reports `used = 0` via
+`statvfs`. The symptom is a log line like `Capacity: hot pool 0% full (0.0 GB /
+35.4 TB)` even when the pool is nearly half full. A `WARNING` is logged when
+this is detected.
+
+**Choose a fix based on your situation:**
+
+**Option A — Unraid Connect GraphQL API (recommended, Unraid 6.12+):**
+Fully automatic — no pool-size config needed. Get an API key from the Unraid UI
+under **Settings → Management Access → API Keys → New Key**, then set in
+`tiering.yaml`:
+
+```yaml
+capacity:
+  unraid_api_url: "http://192.168.1.100/graphql"   # your Unraid host IP
+  unraid_api_key: "your-api-key-here"
+  unraid_pool_name: null   # auto-matched; set to e.g. "Zfs_media" if needed
+```
+
+**Option B — set `hot_pool_total_gb` in `tiering.yaml` (simpler, no API key):**
+Find your pool's total size in GB by running on the **Unraid host**. The
+commands below derive the pool name directly from your `hot_pool_mount` path:
+
+```bash
+# Run on Unraid host. Replace /mnt/hot_pool with your paths.hot_pool_mount value.
+
+# Step 1 — find the ZFS pool name from the mount point:
+awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts
+
+# Step 2 — get pool size in GB (replace Zfs_media with the name from step 1):
+zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'
+
+# Or as a single combined command:
+POOL=$(awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts) \
+  && zpool list -Hp -o size $POOL | awk -v p="$POOL" '{printf "%d GB (%s)\n", $1/1024/1024/1024, p}'
+```
+
+Then set in `tiering.yaml`:
+
+```yaml
+capacity:
+  hot_pool_total_gb: 65536   # your pool size in GB (65536 = 64 TB)
+```
+
+`tier.py` uses `statvfs` for free space (which IS correct on ZFS) and derives
+`used = configured_total − free`. Requires a one-time manual config entry and
+an update if you expand the pool (add vdevs or replace drives).
+
 ### Hot pool ceiling and promotion budget
 
 ```yaml
@@ -736,13 +798,14 @@ that don't fit get the outcome **`OVER_BUDGET_HOT`** — they stay warm this run
 and try again next time as scores evolve. If the budget is zero or negative,
 all `TO_HOT` items are deferred.
 
-The Capacity section of the log (before the move table) shows the full
-accounting:
+The Capacity section of the log shows the full accounting, with one line per
+warm disk so you can spot disks approaching their ceiling:
 
 ```
-Capacity: hot pool 67% full (10.2 / 15.0 TB) — budget 1.8 TB to 80% ceiling
+Capacity: hot pool 39% full (24.9 / 63.8 TB) — budget 26.1 TB to 80% ceiling
 Capacity: 47 TO_HOT candidates totalling 3.4 TB — fitting 24 within budget, 23 deferred (OVER_BUDGET_HOT)
-Capacity: warm disks all under 90% ceiling
+Capacity: warm disk /mnt/disk1 — 4.2 / 8.0 TB (53%)
+Capacity: warm disk /mnt/disk2 — 7.6 / 8.0 TB (95%)  ← over 90% ceiling
 ```
 
 ### Warm disk ceiling

--- a/README.md
+++ b/README.md
@@ -744,9 +744,9 @@ under **Settings → Management Access → API Keys → New Key**, then set in
 
 ```yaml
 capacity:
-  unraid_api_url: "http://192.168.1.100/graphql"   # your Unraid host IP
+  unraid_api_url: "https://192.168.1.100/graphql"  # must be https — http redirects with 302
   unraid_api_key: "your-api-key-here"
-  unraid_pool_name: null   # auto-matched; set to e.g. "Zfs_media" if needed
+  unraid_pool_name: null   # auto-matched from hot_pool_mount; set explicitly if needed
 ```
 
 **Option B — set `hot_pool_total_gb` in `tiering.yaml` (simpler, no API key):**

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -294,12 +294,15 @@ capacity:
   #   # Step 1 — find ZFS pool name from the mount point:
   #   awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts
   #
-  #   # Step 2 — get size in GB (replace Zfs_media with pool name from step 1):
-  #   zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'
+  #   # Step 2 — get USABLE size in GiB (accounts for RAIDZ parity overhead).
+  #   # Use 'zfs get' (ZFS dataset layer) — 'zpool list' size/alloc/free are raw
+  #   # vdev bytes and do NOT reflect parity overhead. Replace Zfs_media below:
+  #   zfs get -Hp -o value available,used Zfs_media | awk '{s+=$1} END {printf "%d\n", s/1024/1024/1024}'
   #
   #   # Or as a single command:
   #   POOL=$(awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts) \
-  #     && zpool list -Hp -o size $POOL | awk -v p="$POOL" '{printf "%d GB (%s)\n", $1/1024/1024/1024, p}'
+  #     && zfs get -Hp -o value available,used $POOL \
+  #     | awk -v p="$POOL" '{s+=$1} END {printf "%d (%s)\n", s/1024/1024/1024, p}'
   #
   # Update this value if you expand the pool (add vdevs / replace drives).
   hot_pool_total_gb: null

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -237,9 +237,10 @@ moves:
 #   If the budget is zero or negative, ALL TO_HOT items are deferred.
 #
 # Dry-run output includes a Capacity: section before the move table:
-#   Capacity: hot pool 67% full (10.2 / 15.0 TB) — budget 1.8 TB to 80% ceiling
+#   Capacity: hot pool 39% full (24.9 / 63.8 TB) — budget 26.1 TB to 80% ceiling
 #   Capacity: 47 TO_HOT candidates totalling 3.4 TB — fitting 24, 23 deferred
-#   Capacity: warm disks all under 90% ceiling
+#   Capacity: warm disk /mnt/disk1 — 4.2 / 8.0 TB (53%)
+#   Capacity: warm disk /mnt/disk2 — 7.6 / 8.0 TB (95%)  ← over 90% ceiling
 capacity:
   # Refuse to fill the hot ZFS pool past this percentage.
   # ZFS write performance degrades above ~80%; snapshots need headroom too.
@@ -263,3 +264,43 @@ capacity:
   # Set to 0 to use the ceiling as the hard limit with no extra margin.
   budget_safety_margin_gb: 0
   # - 100   # example: keep an extra 100 GB back from the ceiling
+
+  # --- Hot pool capacity detection ---
+  #
+  # tier.py needs accurate ZFS pool stats (total/used). statvfs inside Docker
+  # returns used=0 when all files live in ZFS child datasets — symptom is
+  # "0% full" in the Capacity log. Configure ONE of the two options below.
+  #
+  # Detection priority (first success wins):
+  #   1. Unraid Connect GraphQL API  ← configure below if you have an API key
+  #   2. 'zpool' command             ← works if ZFS tools happen to be installed
+  #   3. /proc/spl kstat             ← works with: --volume /proc/spl:/proc/spl:ro
+  #   4. hot_pool_total_gb override  ← configure below as a simpler fallback
+  #   5. statvfs                     ← WARNING logged when used=0 (unreliable for ZFS)
+
+  # Option A — Unraid Connect GraphQL API (Unraid 6.12+).
+  # Get an API key: Unraid UI → Settings → Management Access → API Keys → New Key.
+  # The URL is your Unraid host IP on port 80 (or 443 if HTTPS is enabled).
+  # Advantage: fully automatic, no pool-name config needed in most cases.
+  unraid_api_url: null       # e.g. "http://192.168.1.100/graphql"
+  unraid_api_key: null       # API key string from the Unraid UI
+  unraid_pool_name: null     # ZFS pool name (e.g. "Zfs_media"); auto-matched if null
+
+  # Option B — manual pool size override.
+  # Advantage: no API key needed; works everywhere; requires one-time config.
+  # Run the commands below on the Unraid host to find your pool size.
+  # Replace /mnt/hot_pool with your paths.hot_pool_mount value:
+  #
+  #   # Step 1 — find ZFS pool name from the mount point:
+  #   awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts
+  #
+  #   # Step 2 — get size in GB (replace Zfs_media with pool name from step 1):
+  #   zpool list -Hp -o size Zfs_media | awk '{printf "%d\n", $1/1024/1024/1024}'
+  #
+  #   # Or as a single command:
+  #   POOL=$(awk '$2=="/mnt/hot_pool" && $3=="zfs" {split($1,a,"/"); print a[1]; exit}' /proc/mounts) \
+  #     && zpool list -Hp -o size $POOL | awk -v p="$POOL" '{printf "%d GB (%s)\n", $1/1024/1024/1024, p}'
+  #
+  # Update this value if you expand the pool (add vdevs / replace drives).
+  hot_pool_total_gb: null
+  # hot_pool_total_gb: 65536                     # example: 64 TB (64 × 1024 GB)

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -226,22 +226,40 @@ moves:
     # bytes already on the target, but the simple upper-bound is safer.
     safety_margin_gb: 50
 
-# Capacity — not used in P0, wired up in P3.
-# Budget-aware promotion/demotion keeps the hot ZFS pool under the ceiling.
+# Capacity-aware tiering (P3) — keeps the hot ZFS pool under a fill ceiling
+# and optionally demotes lowest-scoring items when the pool is already over.
+#
+# How the promotion budget works:
+#   budget = (hot_ceiling_percent / 100 × pool_total) - pool_used - safety_margin
+#   TO_HOT candidates are sorted by score descending; each item is allocated
+#   from the budget in order. Items that don't fit become OVER_BUDGET_HOT
+#   (they stay warm this run and try again next time as scores evolve).
+#   If the budget is zero or negative, ALL TO_HOT items are deferred.
+#
+# Dry-run output includes a Capacity: section before the move table:
+#   Capacity: hot pool 67% full (10.2 / 15.0 TB) — budget 1.8 TB to 80% ceiling
+#   Capacity: 47 TO_HOT candidates totalling 3.4 TB — fitting 24, 23 deferred
+#   Capacity: warm disks all under 90% ceiling
 capacity:
-  hot_pool_ceiling_pct: 80      # ZFS performance degrades past this
-  warm_disk_min_free_pct: 15    # skip array disks tighter than this
+  # Refuse to fill the hot ZFS pool past this percentage.
+  # ZFS write performance degrades above ~80%; snapshots need headroom too.
+  hot_ceiling_percent: 80
 
-# Co-location rules — P2 warm-array placement.
-# Series move as a unit; we pick ONE array disk per series so a binge
-# spins up one disk, not many.
-colocation:
-  enforce_single_disk_per_series: true
-  allow_split_fallback: true    # if no single disk fits, log + split
+  # Skip warm array disks that are already at or above this fill level when
+  # selecting a destination for TO_WARM and RELOCATE_WARM moves. An over-
+  # ceiling disk is simply excluded from candidates; if no disks qualify the
+  # item is logged as [FAILED] and left in place until space frees up.
+  warm_per_disk_ceiling_percent: 90
 
-# Safety — not used in P0, wired up in P2/P3.
-safety:
-  min_dest_free_pct: 15
-  max_move_size_per_run_gb: 500
-  refuse_if_plex_unreachable: true
-  skip_currently_playing: true
+  # When true and the hot pool is already over the ceiling, auto-demote the
+  # lowest-scoring STAY_HOT items to TO_WARM until the pool would come back
+  # under the ceiling. PIN_HOT items (library/title/collection pins) are
+  # always exempt — never demote an explicit pin.
+  # Default: false — opt-in once you've confirmed the ceiling is set correctly.
+  auto_demote_when_over_ceiling: false
+
+  # Extra headroom to reserve inside the ceiling (GB). Useful to account for
+  # snapshot growth or concurrent in-progress downloads during the run.
+  # Set to 0 to use the ceiling as the hard limit with no extra margin.
+  budget_safety_margin_gb: 0
+  # - 100   # example: keep an extra 100 GB back from the ceiling

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -282,7 +282,7 @@ capacity:
   # Get an API key: Unraid UI → Settings → Management Access → API Keys → New Key.
   # The URL is your Unraid host IP on port 80 (or 443 if HTTPS is enabled).
   # Advantage: fully automatic, no pool-name config needed in most cases.
-  unraid_api_url: null       # e.g. "http://192.168.1.100/graphql"
+  unraid_api_url: null       # e.g. "https://192.168.1.100/graphql"  (must be https)
   unraid_api_key: null       # API key string from the Unraid UI
   unraid_pool_name: null     # ZFS pool name (e.g. "Zfs_media"); auto-matched if null
 

--- a/tier.py
+++ b/tier.py
@@ -2026,58 +2026,108 @@ def _disk_usage(path: str):
     return shutil.disk_usage(path)
 
 
-def _try_zpool_usage(mount: str) -> Optional[Tuple[int, int]]:
-    """Return (total_bytes, alloc_bytes) for the ZFS pool containing mount.
+def _zfs_pool_name_for_mount(mount: str) -> Optional[str]:
+    """Return ZFS pool name for mount by parsing /proc/mounts (no ZFS tools needed).
 
-    shutil.disk_usage on a ZFS root dataset returns refdbytes (bytes stored
-    directly in that dataset) as 'used' — which is 0 when all files live in
-    child datasets.  Pool-level accounting requires 'zpool list'.
-
-    Runs 'zfs list' to find the pool name, then 'zpool list -Hp -o size,alloc'.
-    Returns None if ZFS commands are unavailable, the mount is not a ZFS
-    filesystem, or any step fails.
+    Docker containers' /proc/mounts reflects bind-mounts with the original ZFS
+    device name (e.g. 'Zfs_media /mnt/hot_pool zfs rw,...').  The pool name is
+    the first path component of the device name.  Returns None for non-ZFS mounts
+    or if /proc/mounts is unreadable.
     """
+    mount_norm = mount.rstrip("/")
+    best_len = -1
+    best_device: Optional[str] = None
+    try:
+        with open("/proc/mounts") as _f:
+            for line in _f:
+                cols = line.split()
+                if len(cols) < 3 or cols[2] != "zfs":
+                    continue
+                mnt = cols[1].rstrip("/")
+                if mount_norm == mnt or mount_norm.startswith(mnt + "/"):
+                    if len(mnt) > best_len:
+                        best_len = len(mnt)
+                        best_device = cols[0]
+    except OSError:
+        pass
+    if best_device:
+        return best_device.split("/")[0]
+    return None
+
+
+def _try_zpool_cmd(pool_name: str) -> Optional[Tuple[int, int]]:
+    """Return (total, alloc) via 'zpool list' command.  None if unavailable."""
     try:
         r = subprocess.run(
-            ["zfs", "list", "-H", "-o", "name,mountpoint"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode != 0:
-            return None
-        mount_norm = mount.rstrip("/")
-        pool_name = None
-        for line in r.stdout.strip().splitlines():
-            parts = line.split("\t")
-            if len(parts) >= 2 and parts[1].rstrip("/") == mount_norm:
-                pool_name = parts[0].split("/")[0]
-                break
-        if not pool_name:
-            return None
-        r2 = subprocess.run(
             ["zpool", "list", "-Hp", "-o", "size,alloc", pool_name],
             capture_output=True, text=True, timeout=5,
         )
-        if r2.returncode != 0:
-            return None
-        parts2 = r2.stdout.strip().split()
-        if len(parts2) >= 2:
-            return int(parts2[0]), int(parts2[1])
+        if r.returncode == 0:
+            parts = r.stdout.strip().split()
+            if len(parts) >= 2:
+                return int(parts[0]), int(parts[1])
     except Exception:  # noqa: BLE001
         pass
     return None
 
 
+def _try_zpool_kstat(pool_name: str) -> Optional[Tuple[int, int]]:
+    """Return (total, used) from /proc/spl/kstat/zfs/<pool>/objset-* kernel stats.
+
+    Sums dk_referenced across all datasets for pool-wide used bytes.  Reads
+    dk_available (pool free space) from any objset file.  Accessible inside
+    Docker containers on Unraid without ZFS userspace tools — the kernel module
+    exposes these stats globally via procfs.
+    Returns None if the kstat directory doesn't exist or stats are missing.
+    """
+    kstat_dir = f"/proc/spl/kstat/zfs/{pool_name}"
+    if not os.path.isdir(kstat_dir):
+        return None
+    total_referenced = 0
+    available: Optional[int] = None
+    try:
+        for fname in os.listdir(kstat_dir):
+            if not fname.startswith("objset-"):
+                continue
+            try:
+                kv: dict = {}
+                with open(os.path.join(kstat_dir, fname)) as _f:
+                    for line in _f:
+                        cols = line.split()
+                        if len(cols) >= 3:
+                            kv[cols[0]] = cols[2]
+                if "dk_referenced" in kv:
+                    total_referenced += int(kv["dk_referenced"])
+                if "dk_available" in kv and available is None:
+                    available = int(kv["dk_available"])
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        return None
+    if available is None:
+        return None
+    return total_referenced + available, total_referenced
+
+
 def _pool_usage_bytes(mount: str) -> Tuple[int, int]:
     """Return (total_bytes, used_bytes) for the hot pool at mount.
 
-    Tries ZFS pool-level accounting first (accurate for pools where files
-    live in child datasets).  Falls back to shutil.disk_usage for non-ZFS
-    filesystems or when ZFS tools are unavailable.
+    Tries three methods in order — stopping at the first that works:
+    1. zpool command (accurate, requires ZFS userspace tools in container).
+    2. /proc/spl/kstat/zfs/ kernel stats (accurate inside Docker, no tools needed).
+    3. shutil.disk_usage fallback (correct for non-ZFS; wrong for ZFS pools
+       where files live in child datasets — refdbytes shows 0 as 'used').
     """
-    zfs = _try_zpool_usage(mount)
-    if zfs is not None:
-        log.debug("Capacity: hot pool stats via zpool (ZFS-accurate): total=%d alloc=%d", *zfs)
-        return zfs
+    pool_name = _zfs_pool_name_for_mount(mount)
+    if pool_name:
+        result = _try_zpool_cmd(pool_name)
+        if result is not None:
+            log.debug("Capacity: hot pool via zpool cmd: total=%d alloc=%d", *result)
+            return result
+        result = _try_zpool_kstat(pool_name)
+        if result is not None:
+            log.debug("Capacity: hot pool via kstat: total=%d used=%d", *result)
+            return result
     try:
         du = _disk_usage(mount)
         return du.total, du.used

--- a/tier.py
+++ b/tier.py
@@ -2129,35 +2129,28 @@ def _try_unraid_api(
     api_url: str,
     api_key: Optional[str],
     pool_name_filter: Optional[str],
+    hot_mount: str = "",
     free_floor_bytes: int = 0,
 ) -> Optional[Tuple[int, int]]:
     """Query the Unraid Connect GraphQL API for ZFS pool capacity.
 
-    Requires Unraid 6.12+ with Unraid Connect enabled and an API key
-    (Settings → Management Access → API keys in the Unraid UI).
+    Requires Unraid 6.12+ with an API key (Settings → Management Access →
+    API keys in the Unraid UI).  Uses the `array { caches }` query — ZFS
+    pools are modelled as cache entries in the Unraid array API.
 
-    pool_name_filter: match exactly this pool name (case-insensitive) if set.
-    free_floor_bytes: skip pools whose total is smaller than this value; used
-                      as a sanity heuristic when pool_name_filter is None.
+    Matching priority (first match wins):
+    1. pool_name_filter (capacity.unraid_pool_name config key) — exact,
+       case-insensitive match on the cache name.
+    2. Last path component of hot_mount — e.g. "/mnt/zfs_media" → "zfs_media".
+    3. First ZFS cache whose fsSize >= free_floor_bytes (size heuristic).
 
-    Returns (total_bytes, used_bytes) or None on any failure.  Failures are
-    always DEBUG-logged so an unconfigured or unavailable endpoint does not
-    produce WARNING/ERROR noise.
+    Returns (total_bytes, used_bytes) or None on any failure.  All failures
+    are DEBUG-logged so an unconfigured endpoint produces no noise.
     """
     import json
     import urllib.request
 
-    query = """
-    query {
-      pools {
-        name
-        filesystem
-        capacity {
-          kilobytes { total used free }
-        }
-      }
-    }
-    """
+    query = "{ array { caches { name fsType fsSize fsFree fsUsed } } }"
     try:
         payload = json.dumps({"query": query}).encode()
         req = urllib.request.Request(
@@ -2179,30 +2172,49 @@ def _try_unraid_api(
         log.debug("Capacity: Unraid API returned errors: %s", errors)
         return None
 
-    pools = (data.get("data") or {}).get("pools") or []
-    for pool in pools:
-        name = (pool.get("name") or "").strip()
-        fs = (pool.get("filesystem") or "").lower()
-        if pool_name_filter and name.lower() != pool_name_filter.lower():
+    caches = (data.get("data") or {}).get("array", {}).get("caches") or []
+
+    # Build candidate name filters in priority order.
+    name_candidates: List[str] = []
+    if pool_name_filter:
+        name_candidates.append(pool_name_filter.lower())
+    if hot_mount:
+        name_candidates.append(hot_mount.rstrip("/").split("/")[-1].lower())
+
+    def _pick(cache: dict) -> Optional[Tuple[int, int]]:
+        total = int(cache.get("fsSize") or 0)
+        used = int(cache.get("fsUsed") or 0)
+        if not total:
+            return None
+        return total, used
+
+    # Pass 1: name-based match.
+    for candidate in name_candidates:
+        for cache in caches:
+            if (cache.get("name") or "").lower() == candidate:
+                result = _pick(cache)
+                if result:
+                    log.debug(
+                        "Capacity: Unraid API matched cache %r by name: total=%d used=%d",
+                        cache["name"], *result,
+                    )
+                    return result
+
+    # Pass 2: first ZFS cache large enough to be the hot pool.
+    for cache in caches:
+        if (cache.get("fsType") or "").lower() != "zfs":
             continue
-        cap = (pool.get("capacity") or {}).get("kilobytes") or {}
-        total_kb = int(cap.get("total") or 0)
-        used_kb = int(cap.get("used") or 0)
-        total_bytes = total_kb * 1024
-        used_bytes = used_kb * 1024
-        if not total_bytes:
-            continue
-        if not pool_name_filter and total_bytes < free_floor_bytes:
-            continue
-        log.debug(
-            "Capacity: Unraid API matched pool %r (fs=%s): total=%d used=%d",
-            name, fs, total_bytes, used_bytes,
-        )
-        return total_bytes, used_bytes
+        result = _pick(cache)
+        if result and result[0] >= free_floor_bytes:
+            log.debug(
+                "Capacity: Unraid API matched cache %r by size heuristic: total=%d used=%d",
+                cache.get("name"), *result,
+            )
+            return result
 
     log.debug(
-        "Capacity: Unraid API returned %d pool(s) — no match for filter=%r",
-        len(pools), pool_name_filter,
+        "Capacity: Unraid API found %d cache(s) — no ZFS match for filter=%r mount=%r",
+        len(caches), pool_name_filter, hot_mount,
     )
     return None
 
@@ -2237,7 +2249,8 @@ def _pool_usage_bytes(
         except OSError:
             free_floor = 0
         result = _try_unraid_api(
-            unraid_api_url, unraid_api_key, unraid_pool_name, free_floor_bytes=free_floor,
+            unraid_api_url, unraid_api_key, unraid_pool_name,
+            hot_mount=mount, free_floor_bytes=free_floor,
         )
         if result is not None:
             log.debug("Capacity: hot pool via Unraid API: total=%d used=%d", *result)

--- a/tier.py
+++ b/tier.py
@@ -240,6 +240,22 @@ DEFAULT_CONFIG = {
         # Additional headroom to leave inside the ceiling (GB). Useful to
         # account for snapshot growth or concurrent writes during the run.
         "budget_safety_margin_gb": 0,
+        # Manual hot pool size override (GB). Only needed when the hot pool is
+        # a ZFS pool and auto-detection fails inside the Docker container (the
+        # common symptom is "0% full" in the Capacity log line). See
+        # example.tiering.yaml for how to find the right value.
+        # Detection chain: Unraid API → zpool cmd → /proc/spl kstat → this override → statvfs.
+        "hot_pool_total_gb": None,
+        # Unraid Connect GraphQL API — queries pool stats without needing ZFS tools
+        # or config overrides. Requires Unraid 6.12+ with an API key from the
+        # Unraid Connect dashboard (Settings → Management Access → API keys).
+        # Leave url null to disable (no network call is made).
+        "unraid_api_url": None,
+        "unraid_api_key": None,
+        # ZFS pool name as Unraid reports it (e.g. "Zfs_media"). When null, the
+        # first ZFS pool returned by the API that is at least as large as
+        # statvfs.free is used as the match heuristic.
+        "unraid_pool_name": None,
     },
 }
 
@@ -2109,15 +2125,125 @@ def _try_zpool_kstat(pool_name: str) -> Optional[Tuple[int, int]]:
     return total_referenced + available, total_referenced
 
 
-def _pool_usage_bytes(mount: str) -> Tuple[int, int]:
+def _try_unraid_api(
+    api_url: str,
+    api_key: Optional[str],
+    pool_name_filter: Optional[str],
+    free_floor_bytes: int = 0,
+) -> Optional[Tuple[int, int]]:
+    """Query the Unraid Connect GraphQL API for ZFS pool capacity.
+
+    Requires Unraid 6.12+ with Unraid Connect enabled and an API key
+    (Settings → Management Access → API keys in the Unraid UI).
+
+    pool_name_filter: match exactly this pool name (case-insensitive) if set.
+    free_floor_bytes: skip pools whose total is smaller than this value; used
+                      as a sanity heuristic when pool_name_filter is None.
+
+    Returns (total_bytes, used_bytes) or None on any failure.  Failures are
+    always DEBUG-logged so an unconfigured or unavailable endpoint does not
+    produce WARNING/ERROR noise.
+    """
+    import json
+    import urllib.request
+
+    query = """
+    query {
+      pools {
+        name
+        filesystem
+        capacity {
+          kilobytes { total used free }
+        }
+      }
+    }
+    """
+    try:
+        payload = json.dumps({"query": query}).encode()
+        req = urllib.request.Request(
+            api_url,
+            data=payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        if api_key:
+            req.add_header("x-api-key", api_key)
+        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+    except Exception as exc:  # noqa: BLE001
+        log.debug("Capacity: Unraid API request failed: %s", exc)
+        return None
+
+    errors = data.get("errors")
+    if errors:
+        log.debug("Capacity: Unraid API returned errors: %s", errors)
+        return None
+
+    pools = (data.get("data") or {}).get("pools") or []
+    for pool in pools:
+        name = (pool.get("name") or "").strip()
+        fs = (pool.get("filesystem") or "").lower()
+        if pool_name_filter and name.lower() != pool_name_filter.lower():
+            continue
+        cap = (pool.get("capacity") or {}).get("kilobytes") or {}
+        total_kb = int(cap.get("total") or 0)
+        used_kb = int(cap.get("used") or 0)
+        total_bytes = total_kb * 1024
+        used_bytes = used_kb * 1024
+        if not total_bytes:
+            continue
+        if not pool_name_filter and total_bytes < free_floor_bytes:
+            continue
+        log.debug(
+            "Capacity: Unraid API matched pool %r (fs=%s): total=%d used=%d",
+            name, fs, total_bytes, used_bytes,
+        )
+        return total_bytes, used_bytes
+
+    log.debug(
+        "Capacity: Unraid API returned %d pool(s) — no match for filter=%r",
+        len(pools), pool_name_filter,
+    )
+    return None
+
+
+def _pool_usage_bytes(
+    mount: str,
+    total_gb_override: Optional[float] = None,
+    unraid_api_url: Optional[str] = None,
+    unraid_api_key: Optional[str] = None,
+    unraid_pool_name: Optional[str] = None,
+) -> Tuple[int, int]:
     """Return (total_bytes, used_bytes) for the hot pool at mount.
 
-    Tries three methods in order — stopping at the first that works:
-    1. zpool command (accurate, requires ZFS userspace tools in container).
-    2. /proc/spl/kstat/zfs/ kernel stats (accurate inside Docker, no tools needed).
-    3. shutil.disk_usage fallback (correct for non-ZFS; wrong for ZFS pools
-       where files live in child datasets — refdbytes shows 0 as 'used').
+    Priority chain — stops at the first successful method:
+
+    1. Unraid Connect GraphQL API — if capacity.unraid_api_url is configured.
+       Accurate, no ZFS tools needed, works inside Docker via the host network.
+       Requires Unraid 6.12+ and an API key.
+    2. zpool command — accurate; requires ZFS userspace tools in the container.
+    3. /proc/spl kstat — accurate inside Docker when /proc/spl is bind-mounted
+                         from the host (no ZFS tools needed).
+    4. hot_pool_total_gb config override — user supplies pool total; statvfs.free
+                         (correct on ZFS) is used to derive used = total − free.
+    5. statvfs fallback — correct for non-ZFS; wrong for ZFS child datasets.
+                         Emits a WARNING when used=0 to prompt configuration.
     """
+    # --- Method 1: Unraid Connect GraphQL API ---
+    if unraid_api_url:
+        try:
+            du = _disk_usage(mount)
+            free_floor = du.free  # heuristic: pool total must be >= statvfs free
+        except OSError:
+            free_floor = 0
+        result = _try_unraid_api(
+            unraid_api_url, unraid_api_key, unraid_pool_name, free_floor_bytes=free_floor,
+        )
+        if result is not None:
+            log.debug("Capacity: hot pool via Unraid API: total=%d used=%d", *result)
+            return result
+
+    # --- Methods 2 & 3: zpool command / /proc/spl kstat ---
     pool_name = _zfs_pool_name_for_mount(mount)
     if pool_name:
         result = _try_zpool_cmd(pool_name)
@@ -2128,8 +2254,27 @@ def _pool_usage_bytes(mount: str) -> Tuple[int, int]:
         if result is not None:
             log.debug("Capacity: hot pool via kstat: total=%d used=%d", *result)
             return result
+
+    # --- Method 4: hot_pool_total_gb config override ---
+    if total_gb_override:
+        try:
+            du = _disk_usage(mount)
+            total = int(float(total_gb_override) * 1024 ** 3)
+            used = max(0, total - du.free)
+            log.debug("Capacity: hot pool via config override: total=%d used=%d", total, used)
+            return total, used
+        except OSError:
+            pass
+
+    # --- Method 5: statvfs fallback ---
     try:
         du = _disk_usage(mount)
+        if du.used == 0 and du.total > 0:
+            log.warning(
+                "Capacity: hot pool used=0 — if this is a ZFS pool with files in child "
+                "datasets, configure capacity.unraid_api_url or capacity.hot_pool_total_gb "
+                "in tiering.yaml for accurate reporting. See README for options."
+            )
         return du.total, du.used
     except OSError:
         return 0, 0
@@ -2420,12 +2565,19 @@ def _apply_capacity_budget(
     warm_ceiling_pct = float(cap_cfg.get("warm_per_disk_ceiling_percent") or 90) / 100.0
 
     # --- Hot pool usage ---
-    # _pool_usage_bytes tries 'zpool list' first for accurate ZFS pool-level
-    # accounting (shutil.disk_usage on a ZFS root dataset returns 0 for 'used'
-    # when all files live in child datasets), then falls back to disk_usage.
+    total_gb_override = cap_cfg.get("hot_pool_total_gb") or None
+    unraid_api_url = (cap_cfg.get("unraid_api_url") or "").strip() or None
+    unraid_api_key = (cap_cfg.get("unraid_api_key") or "").strip() or None
+    unraid_pool_name = (cap_cfg.get("unraid_pool_name") or "").strip() or None
     pool_total = pool_used = 0
     if hot_mount:
-        pool_total, pool_used = _pool_usage_bytes(hot_mount)
+        pool_total, pool_used = _pool_usage_bytes(
+            hot_mount,
+            total_gb_override=total_gb_override,
+            unraid_api_url=unraid_api_url,
+            unraid_api_key=unraid_api_key,
+            unraid_pool_name=unraid_pool_name,
+        )
 
     pool_pct = (pool_used / pool_total) if pool_total else 0.0
     ceiling_bytes = int(pool_total * ceiling_pct) if pool_total else 0
@@ -2505,28 +2657,27 @@ def _apply_capacity_budget(
     elif no_demote and auto_demote and over_ceiling:
         log.info("Capacity: --no-demote set — auto-demote pass skipped (pool over ceiling)")
 
-    # --- Warm disk ceiling status ---
+    # --- Warm disk per-disk usage ---
     array_disks = resolve_array_disks(cfg)
     if array_disks:
-        over_warm_ceiling = []
-        for disk in array_disks:
+        ceiling_label = int(warm_ceiling_pct * 100)
+        for disk in sorted(array_disks):
             try:
                 du = _disk_usage(disk)
-                if du.total and (du.used / du.total) >= warm_ceiling_pct:
-                    over_warm_ceiling.append(disk)
+                if not du.total:
+                    continue
+                pct = du.used / du.total * 100
+                over = pct >= warm_ceiling_pct * 100
+                log.info(
+                    "Capacity: warm disk %s — %s / %s (%d%%)%s",
+                    disk,
+                    _fmt_size(du.used / (1024 ** 3)),
+                    _fmt_size(du.total / (1024 ** 3)),
+                    int(pct),
+                    f"  ← over {ceiling_label}% ceiling" if over else "",
+                )
             except OSError:
-                pass
-        if over_warm_ceiling:
-            log.info(
-                "Capacity: %d warm disk(s) over %d%% ceiling: %s",
-                len(over_warm_ceiling), int(warm_ceiling_pct * 100),
-                ", ".join(sorted(over_warm_ceiling)),
-            )
-        else:
-            log.info(
-                "Capacity: warm disks all under %d%% ceiling",
-                int(warm_ceiling_pct * 100),
-            )
+                log.warning("Capacity: warm disk %s — could not read usage", disk)
 
 
 def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:

--- a/tier.py
+++ b/tier.py
@@ -2026,6 +2026,65 @@ def _disk_usage(path: str):
     return shutil.disk_usage(path)
 
 
+def _try_zpool_usage(mount: str) -> Optional[Tuple[int, int]]:
+    """Return (total_bytes, alloc_bytes) for the ZFS pool containing mount.
+
+    shutil.disk_usage on a ZFS root dataset returns refdbytes (bytes stored
+    directly in that dataset) as 'used' — which is 0 when all files live in
+    child datasets.  Pool-level accounting requires 'zpool list'.
+
+    Runs 'zfs list' to find the pool name, then 'zpool list -Hp -o size,alloc'.
+    Returns None if ZFS commands are unavailable, the mount is not a ZFS
+    filesystem, or any step fails.
+    """
+    try:
+        r = subprocess.run(
+            ["zfs", "list", "-H", "-o", "name,mountpoint"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode != 0:
+            return None
+        mount_norm = mount.rstrip("/")
+        pool_name = None
+        for line in r.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 2 and parts[1].rstrip("/") == mount_norm:
+                pool_name = parts[0].split("/")[0]
+                break
+        if not pool_name:
+            return None
+        r2 = subprocess.run(
+            ["zpool", "list", "-Hp", "-o", "size,alloc", pool_name],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r2.returncode != 0:
+            return None
+        parts2 = r2.stdout.strip().split()
+        if len(parts2) >= 2:
+            return int(parts2[0]), int(parts2[1])
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _pool_usage_bytes(mount: str) -> Tuple[int, int]:
+    """Return (total_bytes, used_bytes) for the hot pool at mount.
+
+    Tries ZFS pool-level accounting first (accurate for pools where files
+    live in child datasets).  Falls back to shutil.disk_usage for non-ZFS
+    filesystems or when ZFS tools are unavailable.
+    """
+    zfs = _try_zpool_usage(mount)
+    if zfs is not None:
+        log.debug("Capacity: hot pool stats via zpool (ZFS-accurate): total=%d alloc=%d", *zfs)
+        return zfs
+    try:
+        du = _disk_usage(mount)
+        return du.total, du.used
+    except OSError:
+        return 0, 0
+
+
 def _select_warm_destination(
     item: "Item",
     array_disks: List[str],
@@ -2311,14 +2370,12 @@ def _apply_capacity_budget(
     warm_ceiling_pct = float(cap_cfg.get("warm_per_disk_ceiling_percent") or 90) / 100.0
 
     # --- Hot pool usage ---
+    # _pool_usage_bytes tries 'zpool list' first for accurate ZFS pool-level
+    # accounting (shutil.disk_usage on a ZFS root dataset returns 0 for 'used'
+    # when all files live in child datasets), then falls back to disk_usage.
     pool_total = pool_used = 0
     if hot_mount:
-        try:
-            du = _disk_usage(hot_mount)
-            pool_total = du.total
-            pool_used = du.used
-        except OSError:
-            pass
+        pool_total, pool_used = _pool_usage_bytes(hot_mount)
 
     pool_pct = (pool_used / pool_total) if pool_total else 0.0
     ceiling_bytes = int(pool_total * ceiling_pct) if pool_total else 0

--- a/tier.py
+++ b/tier.py
@@ -2182,8 +2182,10 @@ def _try_unraid_api(
         name_candidates.append(hot_mount.rstrip("/").split("/")[-1].lower())
 
     def _pick(cache: dict) -> Optional[Tuple[int, int]]:
-        total = int(cache.get("fsSize") or 0)
-        used = int(cache.get("fsUsed") or 0)
+        # Unraid API returns fsSize/fsUsed/fsFree in SI kilobytes (1 kB = 1000 bytes).
+        # Multiply by 1000 to get bytes for consistent internal accounting.
+        total = int(cache.get("fsSize") or 0) * 1000
+        used = int(cache.get("fsUsed") or 0) * 1000
         if not total:
             return None
         return total, used

--- a/tier.py
+++ b/tier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-tier.py — Unraid media tiering script (Phase P2.2 + P2.3)
+tier.py — Unraid media tiering script (Phase P3)
 
 Pulls watch history and metadata from Plex, computes a heat score per
 media item (movies + TV series), probes the filesystem to determine
@@ -42,8 +42,11 @@ Phase status:
                     files within /mnt/user/; Plex path references remain
                     valid without a rescan. Only TO_HOT (which moves
                     files outside the union) recommends a rescan.
-  P3  (later)       Hardened safeguards (lock file, currently-playing skip,
-                    free-space check, max-move cap).
+  P3  (done)        Capacity-aware tiering — hot pool ceiling with
+                    promotion budget (OVER_BUDGET_HOT outcome), optional
+                    auto-demote of lowest-scoring HOT items when over
+                    ceiling, warm per-disk ceiling, --no-promote /
+                    --no-demote CLI flags.
   P4  (later)       Scheduled cron + size-triggered wrapper.
 
 Usage:
@@ -220,6 +223,23 @@ DEFAULT_CONFIG = {
         "on_plex_unreachable": True,
         "on_auth_failure": True,
         "on_script_error": True,
+    },
+    # Capacity-aware tiering (P3). Controls the hot pool promotion budget and
+    # optional auto-demotion when the pool is already over ceiling.
+    "capacity": {
+        # Refuse to fill the hot ZFS pool past this percentage.
+        # ZFS performance degrades above ~80%; keep headroom for snapshots.
+        "hot_ceiling_percent": 80,
+        # Skip warm array disks that are above this fill level when selecting
+        # a destination for TO_WARM / RELOCATE_WARM moves.
+        "warm_per_disk_ceiling_percent": 90,
+        # When True and the hot pool is already over the ceiling, force-demote
+        # the lowest-scoring STAY_HOT items to TO_WARM until the pool would
+        # come back under the ceiling. PIN_HOT items are always exempt.
+        "auto_demote_when_over_ceiling": False,
+        # Additional headroom to leave inside the ceiling (GB). Useful to
+        # account for snapshot growth or concurrent writes during the run.
+        "budget_safety_margin_gb": 0,
     },
 }
 
@@ -2001,11 +2021,17 @@ def _disk_free_bytes(path: str) -> int:
         return 0
 
 
+def _disk_usage(path: str):
+    """Return shutil.disk_usage namedtuple for path — module-level for test patching."""
+    return shutil.disk_usage(path)
+
+
 def _select_warm_destination(
     item: "Item",
     array_disks: List[str],
     safety_margin_bytes: int,
     exclude_disk: Optional[str] = None,
+    warm_ceiling_pct: float = 1.0,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Choose a warm disk for TO_WARM or RELOCATE_WARM moves.
 
@@ -2015,16 +2041,31 @@ def _select_warm_destination(
 
     Selection rules:
       1. Exclude exclude_disk (used for RELOCATE_WARM to avoid the source disk).
-      2. Filter by capacity: free >= item.size_bytes + safety_margin_bytes.
-      3. Co-location: when warm_disk_files is non-empty (item already has files
+      2. Filter by ceiling: skip disks already at or above warm_ceiling_pct fill.
+      3. Filter by capacity: free >= item.size_bytes + safety_margin_bytes.
+      4. Co-location: when warm_disk_files is non-empty (item already has files
          on at least one warm disk), prefer the candidate disk that holds the most
          bytes of this item. Applies to series AND to movies with straggler files
          so extras always land on the same spindle as the main title.
-      4. Fallback: most free space.
+      5. Fallback: most free space.
     """
     candidates = [d for d in array_disks if d != exclude_disk]
     if not candidates:
         return None, "no candidate warm disks"
+
+    # Filter by per-disk ceiling before free-space check.
+    if warm_ceiling_pct < 1.0:
+        under_ceiling = []
+        for d in candidates:
+            try:
+                du = _disk_usage(d)
+                if du.total and (du.used / du.total) < warm_ceiling_pct:
+                    under_ceiling.append(d)
+            except OSError:
+                pass
+        if not under_ceiling:
+            return None, f"all warm disks over {int(warm_ceiling_pct * 100)}% ceiling"
+        candidates = under_ceiling
 
     needed = item.size_bytes + safety_margin_bytes
     qualified = [d for d in candidates if _disk_free_bytes(d) >= needed]
@@ -2239,6 +2280,148 @@ def _warm_src_label(item: "Item", files_dict: Optional[Dict[str, List[str]]] = N
     return "?"
 
 
+def _apply_capacity_budget(
+    items: List[Item],
+    cfg: dict,
+    no_promote: bool = False,
+    no_demote: bool = False,
+) -> None:
+    """Apply hot-pool capacity ceiling to TO_HOT promotions, and optionally
+    demote lowest-scoring HOT items when the pool is already over ceiling.
+
+    Promotion budget:
+      - Computes budget = ceiling_pct * pool_total - pool_used - safety_margin.
+      - Sorts TO_HOT items by score descending; items that exceed the budget
+        become OVER_BUDGET_HOT (counted in the WARM projected bucket).
+      - If no_promote=True: all TO_HOT → OVER_BUDGET_HOT regardless of budget.
+
+    Auto-demote (optional):
+      - Fires only when pool_used > ceiling_bytes AND
+        auto_demote_when_over_ceiling=true AND no_demote=False.
+      - Flips lowest-scoring STAY_HOT items to TO_WARM until the pool would
+        come under the ceiling. PIN_HOT items are always exempt.
+    """
+    cap_cfg = cfg.get("capacity") or {}
+    paths_cfg = cfg.get("paths") or {}
+    hot_mount = (paths_cfg.get("hot_pool_mount") or "").rstrip("/")
+
+    ceiling_pct = float(cap_cfg.get("hot_ceiling_percent") or 80) / 100.0
+    safety_margin_bytes = int(float(cap_cfg.get("budget_safety_margin_gb") or 0) * 1024 ** 3)
+    auto_demote = bool(cap_cfg.get("auto_demote_when_over_ceiling", False))
+    warm_ceiling_pct = float(cap_cfg.get("warm_per_disk_ceiling_percent") or 90) / 100.0
+
+    # --- Hot pool usage ---
+    pool_total = pool_used = 0
+    if hot_mount:
+        try:
+            du = _disk_usage(hot_mount)
+            pool_total = du.total
+            pool_used = du.used
+        except OSError:
+            pass
+
+    pool_pct = (pool_used / pool_total) if pool_total else 0.0
+    ceiling_bytes = int(pool_total * ceiling_pct) if pool_total else 0
+    over_ceiling = bool(pool_total and pool_used > ceiling_bytes)
+    budget_bytes = max(0, ceiling_bytes - pool_used - safety_margin_bytes) if pool_total else 0
+
+    if pool_total:
+        log.info(
+            "Capacity: hot pool %d%% full (%s / %s) — budget %s to %d%% ceiling%s",
+            int(pool_pct * 100),
+            _fmt_size(pool_used / (1024 ** 3)),
+            _fmt_size(pool_total / (1024 ** 3)),
+            _fmt_size(budget_bytes / (1024 ** 3)),
+            int(ceiling_pct * 100),
+            " (after safety margin)" if safety_margin_bytes else "",
+        )
+    else:
+        log.debug(
+            "Capacity: hot pool stats unavailable (hot_pool_mount=%r not set or inaccessible)",
+            hot_mount or "",
+        )
+
+    # --- Promotion budget ---
+    to_hot_items = sorted(
+        [it for it in items if it.outcome == "TO_HOT"],
+        key=lambda it: -it.score,
+    )
+    to_hot_total_bytes = sum(it.size_bytes for it in to_hot_items)
+
+    if no_promote:
+        for it in to_hot_items:
+            it.outcome = "OVER_BUDGET_HOT"
+        if to_hot_items:
+            log.info(
+                "Capacity: --no-promote set — all %d TO_HOT items (%s) deferred (OVER_BUDGET_HOT)",
+                len(to_hot_items), _fmt_size(to_hot_total_bytes / (1024 ** 3)),
+            )
+    elif to_hot_items:
+        remaining = budget_bytes
+        fit = deferred = 0
+        for it in to_hot_items:
+            if remaining >= it.size_bytes:
+                remaining -= it.size_bytes
+                fit += 1
+            else:
+                it.outcome = "OVER_BUDGET_HOT"
+                deferred += 1
+        log.info(
+            "Capacity: %d TO_HOT candidates totalling %s — fitting %d within budget, "
+            "%d deferred (OVER_BUDGET_HOT)",
+            len(to_hot_items), _fmt_size(to_hot_total_bytes / (1024 ** 3)), fit, deferred,
+        )
+
+    # --- Auto-demote when over ceiling ---
+    if over_ceiling and auto_demote and not no_demote:
+        bytes_to_shed = pool_used - ceiling_bytes
+        demote_candidates = sorted(
+            [it for it in items if it.outcome == "STAY_HOT"],
+            key=lambda it: it.score,
+        )
+        shed = demoted = 0
+        for it in demote_candidates:
+            if shed >= bytes_to_shed:
+                break
+            it.outcome = "TO_WARM"
+            shed += it.size_bytes
+            demoted += 1
+        pool_after_pct = ((pool_used - shed) / pool_total * 100) if pool_total else 0.0
+        log.info(
+            "Capacity: hot pool %d%% full — over %d%% ceiling, demoting lowest scorers",
+            int(pool_pct * 100), int(ceiling_pct * 100),
+        )
+        log.info(
+            "Capacity: demoted %d items (%s) to TO_WARM to bring pool to %.1f%%",
+            demoted, _fmt_size(shed / (1024 ** 3)), pool_after_pct,
+        )
+    elif no_demote and auto_demote and over_ceiling:
+        log.info("Capacity: --no-demote set — auto-demote pass skipped (pool over ceiling)")
+
+    # --- Warm disk ceiling status ---
+    array_disks = resolve_array_disks(cfg)
+    if array_disks:
+        over_warm_ceiling = []
+        for disk in array_disks:
+            try:
+                du = _disk_usage(disk)
+                if du.total and (du.used / du.total) >= warm_ceiling_pct:
+                    over_warm_ceiling.append(disk)
+            except OSError:
+                pass
+        if over_warm_ceiling:
+            log.info(
+                "Capacity: %d warm disk(s) over %d%% ceiling: %s",
+                len(over_warm_ceiling), int(warm_ceiling_pct * 100),
+                ", ".join(sorted(over_warm_ceiling)),
+            )
+        else:
+            log.info(
+                "Capacity: warm disks all under %d%% ceiling",
+                int(warm_ceiling_pct * 100),
+            )
+
+
 def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     """Dry-run or execute moves for TO_HOT, TO_WARM, and RELOCATE_WARM outcomes.
 
@@ -2277,6 +2460,8 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
     safety_margin_bytes = int(float(warm_sel_cfg.get("safety_margin_gb") or 50) * 1024 ** 3)
     hot_bps = int(float(moves_cfg.get("estimated_hot_mbps") or 200)) * 1024 * 1024
     warm_bps = int(float(moves_cfg.get("estimated_warm_mbps") or 50)) * 1024 * 1024
+    cap_cfg = cfg.get("capacity") or {}
+    _warm_ceiling_pct = float(cap_cfg.get("warm_per_disk_ceiling_percent") or 100) / 100.0
 
     # Tally SHOULD_BE_* outcomes (tier unknown — nothing to move).
     skip_outcomes: dict = {}
@@ -2338,7 +2523,10 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
         if not dest_array_disks:
             to_warm_dests[id(it)] = (None, "no warm disks configured")
         else:
-            dst, annot = _select_warm_destination(it, dest_array_disks, safety_margin_bytes)
+            dst, annot = _select_warm_destination(
+                it, dest_array_disks, safety_margin_bytes,
+                warm_ceiling_pct=_warm_ceiling_pct,
+            )
             to_warm_dests[id(it)] = (dst, annot)
         if to_warm_dests[id(it)][0] is None:
             log.error("Moves: [FAILED] %s [TO_WARM] — %s (needs %s + %d GB margin)",
@@ -2352,7 +2540,8 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             relocate_dests[id(it)] = (None, "no warm disks configured")
         else:
             dst, annot = _select_warm_destination(
-                it, dest_array_disks, safety_margin_bytes, exclude_disk=it.current_disk,
+                it, dest_array_disks, safety_margin_bytes,
+                exclude_disk=it.current_disk, warm_ceiling_pct=_warm_ceiling_pct,
             )
             relocate_dests[id(it)] = (dst, annot)
         if relocate_dests[id(it)][0] is None:
@@ -2540,7 +2729,9 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
 # executed. The bucket reflects where the item will END UP, not where it
 # currently sits — so TO_HOT + STAY_HOT + PIN_HOT all go into HOT.
 _HOT_OUTCOMES = {"SHOULD_BE_HOT", "PIN_HOT", "STAY_HOT", "TO_HOT"}
-_WARM_OUTCOMES = {"SHOULD_BE_WARM", "STAY_WARM", "TO_WARM", "RELOCATE_WARM"}
+# OVER_BUDGET_HOT: item scored TO_HOT but the hot pool budget denied promotion.
+# Counted in WARM projected totals — the item stays on warm this run.
+_WARM_OUTCOMES = {"SHOULD_BE_WARM", "STAY_WARM", "TO_WARM", "RELOCATE_WARM", "OVER_BUDGET_HOT"}
 # MIXED_NEUTRAL = item is split 50/50 with no direction to resolve it.
 # Leave under NEUTRAL; P2 takes no action.
 
@@ -2751,6 +2942,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="execute moves (requires moves.enabled=true in config; default is dry-run)",
     )
     p.add_argument(
+        "--no-promote", action="store_true",
+        help="block all TO_HOT moves this run; items become OVER_BUDGET_HOT regardless of budget",
+    )
+    p.add_argument(
+        "--no-demote", action="store_true",
+        help="skip auto-demote pass even if hot pool is over ceiling",
+    )
+    p.add_argument(
         "--log-file", type=Path, default=None,
         help="override logging.path from config",
     )
@@ -2785,6 +2984,14 @@ def _run(args) -> int:
 
     items = collect_all(plex, cfg, filter_libraries=args.library)
     items = apply_sort(items, args.sort)
+
+    # Capacity pass: apply hot pool budget and optional auto-demote before
+    # the move pass so the move queues reflect budget-adjusted outcomes.
+    _apply_capacity_budget(
+        items, cfg,
+        no_promote=getattr(args, "no_promote", False),
+        no_demote=getattr(args, "no_demote", False),
+    )
 
     # Move pass runs on the full scored list before --top truncation so every
     # TO_HOT item is considered regardless of display limit.
@@ -4911,6 +5118,223 @@ def _test_relocate_warm_co_locate_with_existing_partial():
     print("_test_relocate_warm_co_locate_with_existing_partial: OK")
 
 
+# ---------- P3 capacity tests ----------
+
+def _make_cap_cfg(
+    ceiling_pct=80,
+    warm_ceiling_pct=90,
+    safety_gb=0,
+    auto_demote=False,
+):
+    """Build a minimal cfg dict for capacity tests."""
+    return {
+        "paths": {"hot_pool_mount": "/mnt/hot", "array_disks": [], "array_disk_exclude": []},
+        "capacity": {
+            "hot_ceiling_percent": ceiling_pct,
+            "warm_per_disk_ceiling_percent": warm_ceiling_pct,
+            "budget_safety_margin_gb": safety_gb,
+            "auto_demote_when_over_ceiling": auto_demote,
+        },
+    }
+
+
+def _make_fake_disk_usage(total_gb, used_gb):
+    """Return a callable that mimics shutil.disk_usage for test patching."""
+    import collections
+    DU = collections.namedtuple("DU", ["total", "used", "free"])
+    GB = 1024 ** 3
+    total = int(total_gb * GB)
+    used = int(used_gb * GB)
+    return lambda _path: DU(total=total, used=used, free=total - used)
+
+
+def _test_capacity_budget_caps_to_hot_promotions():
+    """High-score item fits within budget; lower-score item is deferred."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        # Pool: 10 TB total, 6 TB used. ceiling=80% → ceiling=8 TB, budget=2 TB.
+        # Item A (score=80, 1.5 TB) fits; item B (score=50, 1 TB) makes total 2.5 TB → deferred.
+        TB = 1024 ** 3 * 1024
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 6 * 1024)  # GB args
+
+        item_a = _make_item(score=80.0, size_bytes=int(1.5 * TB), outcome="TO_HOT")
+        item_b = _make_item(score=50.0, size_bytes=TB, outcome="TO_HOT")
+        items = [item_a, item_b]
+
+        _apply_capacity_budget(items, _make_cap_cfg(ceiling_pct=80, safety_gb=0))
+
+        assert item_a.outcome == "TO_HOT", f"high-score item should fit, got {item_a.outcome}"
+        assert item_b.outcome == "OVER_BUDGET_HOT", f"low-score item should be deferred, got {item_b.outcome}"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_budget_caps_to_hot_promotions: OK")
+
+
+def _test_capacity_budget_zero_makes_all_over_budget():
+    """Pool exactly at ceiling → budget=0 → all TO_HOT items deferred."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        # Pool: 10 TB total, 8 TB used. ceiling=80% → ceiling=8 TB, budget=0.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 8 * 1024)
+
+        items = [
+            _make_item(score=90.0, size_bytes=1, outcome="TO_HOT"),
+            _make_item(score=70.0, size_bytes=1, outcome="TO_HOT"),
+        ]
+        _apply_capacity_budget(items, _make_cap_cfg(ceiling_pct=80, safety_gb=0))
+
+        for it in items:
+            assert it.outcome == "OVER_BUDGET_HOT", f"expected OVER_BUDGET_HOT, got {it.outcome}"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_budget_zero_makes_all_over_budget: OK")
+
+
+def _test_capacity_over_ceiling_auto_demotes_lowest_scorers():
+    """Pool over ceiling + auto_demote=True → lowest STAY_HOT items become TO_WARM."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        GB = 1024 ** 3
+        # Pool: 10 TB, used 9 TB → 90% > 80% ceiling → over by 1 TB.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 9 * 1024)
+
+        # Two STAY_HOT items. Low score is demoted first.
+        item_low = _make_item(score=25.0, size_bytes=int(1.5 * 1024 * GB), outcome="STAY_HOT")
+        item_high = _make_item(score=75.0, size_bytes=int(1.5 * 1024 * GB), outcome="STAY_HOT")
+        items = [item_high, item_low]  # order shouldn't matter; sort by score ascending
+
+        _apply_capacity_budget(items, _make_cap_cfg(ceiling_pct=80, auto_demote=True))
+
+        # Need to shed 1 TB. item_low is 1.5 TB — one demotion is enough.
+        assert item_low.outcome == "TO_WARM", f"expected TO_WARM, got {item_low.outcome}"
+        assert item_high.outcome == "STAY_HOT", f"high-score item should be exempt, got {item_high.outcome}"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_over_ceiling_auto_demotes_lowest_scorers: OK")
+
+
+def _test_capacity_over_ceiling_does_not_demote_pin_hot():
+    """PIN_HOT items are always exempt from auto-demote even when over ceiling."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        # Pool: 10 TB, 9 TB used → over 80% ceiling.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 9 * 1024)
+
+        item_pin = _make_item(score=5.0, size_bytes=int(2 * 1024 * 1024 ** 3), outcome="PIN_HOT")
+        item_stay = _make_item(score=22.0, size_bytes=int(2 * 1024 * 1024 ** 3), outcome="STAY_HOT")
+        items = [item_pin, item_stay]
+
+        _apply_capacity_budget(items, _make_cap_cfg(ceiling_pct=80, auto_demote=True))
+
+        assert item_pin.outcome == "PIN_HOT", f"PIN_HOT must be exempt, got {item_pin.outcome}"
+        # item_stay should be demoted to bring pool under ceiling
+        assert item_stay.outcome == "TO_WARM", f"expected TO_WARM, got {item_stay.outcome}"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_over_ceiling_does_not_demote_pin_hot: OK")
+
+
+def _test_capacity_no_promote_flag_blocks_all_to_hot():
+    """--no-promote converts all TO_HOT items to OVER_BUDGET_HOT regardless of budget."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        # Pool has ample budget — doesn't matter, --no-promote wins.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 1 * 1024)
+
+        items = [
+            _make_item(score=95.0, size_bytes=1, outcome="TO_HOT"),
+            _make_item(score=60.0, size_bytes=1, outcome="TO_HOT"),
+            _make_item(score=30.0, size_bytes=1, outcome="STAY_WARM"),  # unaffected
+        ]
+        _apply_capacity_budget(items, _make_cap_cfg(), no_promote=True)
+
+        assert items[0].outcome == "OVER_BUDGET_HOT"
+        assert items[1].outcome == "OVER_BUDGET_HOT"
+        assert items[2].outcome == "STAY_WARM", "STAY_WARM must be unaffected by --no-promote"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_no_promote_flag_blocks_all_to_hot: OK")
+
+
+def _test_capacity_no_demote_flag_blocks_to_warm():
+    """--no-demote suppresses the auto-demote pass even when pool is over ceiling."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        # Pool: 9 TB / 10 TB → over 80% ceiling. auto_demote=True but no_demote=True.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 9 * 1024)
+
+        item = _make_item(score=22.0, size_bytes=int(2 * 1024 * 1024 ** 3), outcome="STAY_HOT")
+        _apply_capacity_budget(
+            [item], _make_cap_cfg(ceiling_pct=80, auto_demote=True), no_demote=True
+        )
+
+        assert item.outcome == "STAY_HOT", f"--no-demote must block auto-demote, got {item.outcome}"
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_no_demote_flag_blocks_to_warm: OK")
+
+
+def _test_capacity_safety_margin_respected():
+    """Safety margin reduces the effective promotion budget."""
+    global _disk_usage
+    orig = _disk_usage
+    try:
+        GB = 1024 ** 3
+        # Pool: 10 TB, 6 TB used. ceiling=80% → 8 TB, raw budget = 2 TB.
+        # safety_margin = 1.5 TB → effective budget = 0.5 TB.
+        # Item of 1 TB does not fit.
+        _disk_usage = _make_fake_disk_usage(10 * 1024, 6 * 1024)
+
+        item = _make_item(score=80.0, size_bytes=int(1024 * GB), outcome="TO_HOT")
+        _apply_capacity_budget(
+            [item], _make_cap_cfg(ceiling_pct=80, safety_gb=1536)  # 1536 GB = 1.5 TB
+        )
+
+        assert item.outcome == "OVER_BUDGET_HOT", (
+            f"safety margin should shrink budget below item size, got {item.outcome}"
+        )
+    finally:
+        _disk_usage = orig
+    print("_test_capacity_safety_margin_respected: OK")
+
+
+def _test_capacity_warm_per_disk_ceiling_blocks_to_warm_when_full():
+    """All warm disks over the ceiling → _select_warm_destination returns None."""
+    global _disk_usage, _disk_free_bytes
+    orig_du = _disk_usage
+    orig_dfb = _disk_free_bytes
+    try:
+        GB = 1024 ** 3
+        import collections
+        DU = collections.namedtuple("DU", ["total", "used", "free"])
+        # Disks are 95% full; ceiling is 90%.
+        _disk_usage = lambda _p: DU(total=10 * 1024 * GB, used=int(9.5 * 1024 * GB),
+                                    free=int(0.5 * 1024 * GB))
+        _disk_free_bytes = lambda _p: int(0.5 * 1024 * GB)
+
+        item = _make_item(kind="movie", size_bytes=GB)
+        disk, annot = _select_warm_destination(
+            item, ["/mnt/disk1", "/mnt/disk2"],
+            safety_margin_bytes=0,
+            warm_ceiling_pct=0.90,
+        )
+
+        assert disk is None, f"expected None (all disks over ceiling), got {disk}"
+        assert annot is not None and "ceiling" in annot.lower(), (
+            f"expected ceiling message in annotation, got {annot!r}"
+        )
+    finally:
+        _disk_usage = orig_du
+        _disk_free_bytes = orig_dfb
+    print("_test_capacity_warm_per_disk_ceiling_blocks_to_warm_when_full: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -4974,5 +5398,13 @@ if __name__ == "__main__":
         _test_to_warm_full_flow_end_to_end()
         _test_relocate_warm_full_flow_end_to_end()
         _test_relocate_warm_co_locate_with_existing_partial()
+        _test_capacity_budget_caps_to_hot_promotions()
+        _test_capacity_budget_zero_makes_all_over_budget()
+        _test_capacity_over_ceiling_auto_demotes_lowest_scorers()
+        _test_capacity_over_ceiling_does_not_demote_pin_hot()
+        _test_capacity_no_promote_flag_blocks_all_to_hot()
+        _test_capacity_no_demote_flag_blocks_to_warm()
+        _test_capacity_safety_margin_respected()
+        _test_capacity_warm_per_disk_ceiling_blocks_to_warm_when_full()
         sys.exit(0)
     sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a scoring-layer safeguard between `collect_all()` and the move executor that keeps the hot ZFS pool under a configurable fill ceiling. When the pool has room, the highest-scoring `TO_HOT` items are promoted first; lower-priority items become `OVER_BUDGET_HOT` and stay warm until next run. Optionally demotes the lowest-scoring `STAY_HOT` items when the pool is already over the ceiling. Also enforces a per-disk fill ceiling on warm destination selection.

## Config schema

```yaml
capacity:
  hot_ceiling_percent: 80            # refuse to fill ZFS pool past this
  warm_per_disk_ceiling_percent: 90  # skip warm disks above this fill level
  auto_demote_when_over_ceiling: false  # flip lowest-scoring STAY_HOT → TO_WARM when over
  budget_safety_margin_gb: 0         # extra headroom inside the ceiling
```

## Behaviour

- **Promotion budget**: `budget = ceiling_bytes - pool_used - safety_margin`. `TO_HOT` candidates sorted by score desc; items that fit keep `TO_HOT`, extras become `OVER_BUDGET_HOT` (counted in WARM projected totals).
- **`--no-promote` flag**: all `TO_HOT` → `OVER_BUDGET_HOT` this run, regardless of budget.
- **Auto-demote**: when `pool_used > ceiling_bytes` and `auto_demote_when_over_ceiling: true`, lowest-scoring `STAY_HOT` items flip to `TO_WARM` until pool comes under ceiling. `PIN_HOT` items always exempt.
- **`--no-demote` flag**: suppresses auto-demote pass even when over ceiling.
- **Warm disk ceiling**: `_select_warm_destination` excludes disks at or above `warm_per_disk_ceiling_percent`. Items with no qualifying disk log `[FAILED]` and stay in place.
- **Graceful degradation**: if `hot_pool_mount` is unset or inaccessible, budget pass is skipped; `--no-promote` still honoured.
- **Capacity log section** appears before the move table in every run:
  ```
  Capacity: hot pool 67% full (10.2 / 15.0 TB) — budget 1.8 TB to 80% ceiling
  Capacity: 47 TO_HOT candidates totalling 3.4 TB — fitting 24 within budget, 23 deferred (OVER_BUDGET_HOT)
  Capacity: warm disks all under 90% ceiling
  ```

## Tests

8 new tests added to the `--_test` harness, all passing:

- `_test_capacity_budget_caps_to_hot_promotions`
- `_test_capacity_budget_zero_makes_all_over_budget`
- `_test_capacity_over_ceiling_auto_demotes_lowest_scorers`
- `_test_capacity_over_ceiling_does_not_demote_pin_hot`
- `_test_capacity_no_promote_flag_blocks_all_to_hot`
- `_test_capacity_no_demote_flag_blocks_to_warm`
- `_test_capacity_safety_margin_respected`
- `_test_capacity_warm_per_disk_ceiling_blocks_to_warm_when_full`

Full harness: 68 tests, all OK.

## Docs

- **README.md**: new "Capacity-aware tiering (P3)" section; `OVER_BUDGET_HOT` added to outcomes table; P3 phase roadmap updated to Done.
- **AGENTS.md**: phase table updated; design entries for OVER_BUDGET_HOT rationale, PIN_HOT exemption, pool vs per-disk ceiling distinction, budget-vs-100% explanation.
- **example.tiering.yaml**: placeholder `capacity:` block replaced with full documented P3 block.

## Test plan

- [x] Dry-run with default config — confirm `Capacity:` lines show pool usage and budget.
- [ ] Set `hot_ceiling_percent: 1` to force budget ~zero — confirm all `TO_HOT` items become `OVER_BUDGET_HOT`.
- [x] With pool below ceiling, set `auto_demote_when_over_ceiling: true` — confirm no auto-demote fires (correct: not above ceiling).
- [x] Simulate over-ceiling by setting a very low ceiling — confirm auto-demote log triggers and items appear with `TO_WARM`.
- [ ] Run with `--no-promote` — confirm all `TO_HOT` deferred; `--no-demote` — confirm auto-demote suppressed.