### PR TITLE
P4.1: scheduling primitives — lock, run state, exit-code contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ CLAUDE.md and GEMINI.md are symlinks to this file.
 | P2.4 | Plex rescan automation — dropped (Unraid user-share union makes it unnecessary for in-union moves) | N/A |
 | P3   | Capacity-aware tiering — hot pool ceiling + promotion budget (OVER_BUDGET_HOT), optional auto-demote, warm per-disk ceiling, --no-promote / --no-demote | Done |
 | P3.5 | Move hardening — run-level I/O budget (max_total_move_gb) | Done |
-| P4   | Scheduling primitives — lock file, structured exit codes, cron docs | Pending |
+| P4.1 | Scheduling primitives — single-instance lock, run-state file, skip_if_run_within_minutes, exit-code contract | Done |
 
 ## Non-obvious design decisions
 
@@ -797,8 +797,7 @@ that path is a separate read-write mount.
 
 `--apply` executes TO_HOT, TO_WARM, and RELOCATE_WARM moves when
 `moves.enabled: true`. All three directions are serialised in a single
-pass. The lock file (P4) is not yet implemented — concurrent runs are
-not prevented.
+pass.
 
 ### `max_total_move_gb` is a run-time budget, not a correctness guard
 
@@ -814,6 +813,52 @@ A per-item size cap (`max_single_move_gb`) was considered and rejected:
 skipping an item because it is large is arbitrary when the pool-fill case
 is already covered by `OVER_BUDGET_HOT`. The run-level budget is the
 useful version of the idea.
+
+### Scheduling model (P4.1)
+
+All scheduling state lives in `/config/state/` (created automatically on
+first run). Two files are written there:
+
++ `tier.lock` — single-instance lock. Acquired before any Plex connection;
+  released in a `finally` block on every exit path (success, crash, or
+  SIGINT). A hard crash is covered by stale-PID reclaim on the next run.
++ `last_run.json` — persisted after every run that actually executes (not
+  `LOCK_HELD` or `SKIPPED_RECENT`). Contains `started_at`, `finished_at`,
+  `mode`, `exit_code`, and move counters.
+
+**Lock stale-PID reclaim.** On startup, if the lock file exists, we read its
+PID and call `os.kill(pid, 0)`. `ProcessLookupError` (ESRCH) means the
+process is dead — reclaim the lock and continue. `PermissionError` (EPERM)
+means the process IS alive but we cannot signal it — treat as held and exit.
+No exception means the process is alive and is not us — genuine concurrent run.
+
+**Container PID-reuse guard.** Docker one-shot containers start the
+entrypoint as PID 1. If a container crashes without releasing the lock, the
+next container also gets PID 1, so `os.kill(1, 0)` would succeed (we ARE
+PID 1) and we would falsely report `LOCK_HELD`. Guard: if `pid == os.getpid()`,
+the lock is from a prior run that reused our PID — reclaim it unconditionally.
+No live process can hold a lock against itself at startup.
+
+**`LOCK_HELD` and `SKIPPED_RECENT` are expected scheduler outcomes, not errors.**
+They deliberately do not fire the error notifier and do not write `last_run.json`.
+A cron operator seeing code 5 or 6 in mail should not investigate — it is normal.
+
+**Exit code 4 (`UNHANDLED_CRASH`) was not reused for `LOCK_HELD`.** A
+scheduler must be able to distinguish "already running" (not an error,
+retry later) from "crashed" (investigate). Reusing 4 would collapse that
+distinction.
+
+**Full exit-code contract:**
+
+| Code | Name | Meaning | Error? |
+| ---- | ---- | ------- | ------ |
+| 0 | `SUCCESS` | Normal completion | No |
+| 1 | `FATAL_CONFIG` | Config file missing / invalid (implicit string exit) | Yes |
+| 2 | `PLEX_ERROR` | Plex unreachable or auth failed | Yes |
+| 4 | `UNHANDLED_CRASH` | Unhandled exception; error notifier fires | Yes |
+| 5 | `LOCK_HELD` | Another instance is running | No |
+| 6 | `SKIPPED_RECENT` | Within `skip_if_run_within_minutes` window | No |
+| 130 | `KEYBOARD_INTERRUPT` | SIGINT | No |
 
 ### Why there is no currently-playing skip
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -826,18 +826,19 @@ first run). Two files are written there:
   `LOCK_HELD` or `SKIPPED_RECENT`). Contains `started_at`, `finished_at`,
   `mode`, `exit_code`, and move counters.
 
-**Lock stale-PID reclaim.** On startup, if the lock file exists, we read its
-PID and call `os.kill(pid, 0)`. `ProcessLookupError` (ESRCH) means the
-process is dead — reclaim the lock and continue. `PermissionError` (EPERM)
-means the process IS alive but we cannot signal it — treat as held and exit.
-No exception means the process is alive and is not us — genuine concurrent run.
+**Why `fcntl.flock`, not PID liveness.** An earlier design used
+`os.kill(pid, 0)` to check whether the lock holder was still alive. This
+is broken across Docker containers: each container has its own PID namespace,
+so `os.kill()` cannot see another container's process and would wrongly report
+`ProcessLookupError` for a live lock, letting two containers run simultaneously.
 
-**Container PID-reuse guard.** Docker one-shot containers start the
-entrypoint as PID 1. If a container crashes without releasing the lock, the
-next container also gets PID 1, so `os.kill(1, 0)` would succeed (we ARE
-PID 1) and we would falsely report `LOCK_HELD`. Guard: if `pid == os.getpid()`,
-the lock is from a prior run that reused our PID — reclaim it unconditionally.
-No live process can hold a lock against itself at startup.
+`fcntl.flock(LOCK_EX|LOCK_NB)` is correct: it operates at the kernel VFS
+layer. The `/config` directory is a bind-mount of a host-local directory;
+both containers see the same inode, and the kernel's flock is shared across
+the bind-mount. The kernel releases the flock automatically when the process
+or container dies, so "stale lock from crashed run" is handled implicitly —
+no PID inspection or manual cleanup needed. A `BlockingIOError` from the
+non-blocking attempt is the definitive signal that another instance is live.
 
 **`LOCK_HELD` and `SKIPPED_RECENT` are expected scheduler outcomes, not errors.**
 They deliberately do not fire the error notifier and do not write `last_run.json`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ execute; default is dry-run.
 | P2.4 | Plex rescan automation — **intentionally not implemented**. Unraid's user-share union means Plex always reads through `/mnt/user/` regardless of which physical disk backs a file; TO_WARM and RELOCATE_WARM moves are invisible to Plex at the path level. Only TO_HOT (which moves files off the union to a separate ZFS mount) recommends a rescan. | N/A |
 | P3 | Capacity-aware tiering — hot pool fill ceiling, promotion budget, `OVER_BUDGET_HOT` outcome, optional auto-demote of lowest-scoring HOT items, warm per-disk ceiling, `--no-promote` / `--no-demote` flags. | **Done** |
 | P3.5 | Move hardening — run-level I/O budget (`max_total_move_gb`). | **Done** |
-| P4 | Scheduling primitives — lock file, structured exit codes, cron docs. | Pending |
+| P4.1 | Scheduling primitives — single-instance lock with stale-PID reclaim, `last_run.json` state file, `skip_if_run_within_minutes` recency guard, formalised exit-code contract. | **Done** |
 
 ## Install
 
@@ -950,15 +950,48 @@ All thresholds live in `tiering.yaml`. After the first few runs, look for:
 Use `--explain TITLE` to see the scoring math for any single item. Pinned and
 recency-floor promotions appear under the `override` key in the breakdown.
 
+## Scheduling (P4.1)
+
+tier.py is safe to run from cron or any scheduler. It acquires a
+single-instance lock (`/config/state/tier.lock`) at startup — if another
+instance is running the new invocation exits immediately with code 5
+(`LOCK_HELD`) without touching Plex or moving anything. A crashed run's
+stale lock is reclaimed automatically by checking whether the recorded PID
+is still alive.
+
+After every completed run (success or crash), a run-state file
+`/config/state/last_run.json` is written with timing, exit code, and move
+counters. The `skip_if_run_within_minutes` config knob reads this file and
+exits with code 6 (`SKIPPED_RECENT`) if the previous run finished recently
+— useful when a monthly cron and a manual trigger can fire in the same hour.
+
+```yaml
+scheduling:
+  skip_if_run_within_minutes: 0   # 0 = disabled
+```
+
+Both `LOCK_HELD` and `SKIPPED_RECENT` are **expected** scheduler outcomes.
+Seeing them in cron mail does not indicate a failure and does not trigger
+the error notifier.
+
+### Cron example
+
+```
+# Monthly full run, 03:00 on the 1st — offset from Unraid parity check
+0 3 1 * * docker start -a tier
+```
+
 ## Exit codes
 
-| Code | Meaning |
-|---|---|
-| 0 | Success |
-| 1 | Config error (file missing, token placeholder, empty libraries) |
-| 2 | Plex unreachable or auth failed |
-| 4 | Unhandled runtime error (notification fired if configured) |
-| 130 | Interrupted (SIGINT) |
+| Code | Meaning | Error? |
+| --- | --- | --- |
+| 0 | Success | No |
+| 1 | Config error (file missing, token placeholder, empty libraries) | Yes |
+| 2 | Plex unreachable or auth failed | Yes |
+| 4 | Unhandled runtime error (notification fired if configured) | Yes |
+| 5 | Lock held — another tier.py instance is running | No |
+| 6 | Skipped — previous run finished within `skip_if_run_within_minutes` | No |
+| 130 | Interrupted (SIGINT) | No |
 
 ## Repo layout (when published)
 

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -318,3 +318,13 @@ capacity:
   # Update this value if you expand the pool (add vdevs / replace drives).
   hot_pool_total_gb: null
   # hot_pool_total_gb: 65536                     # example: 64 TB (64 × 1024 GB)
+
+# Scheduling primitives (P4.1) — makes tier.py safe to run from cron.
+# All state files (lock, last_run.json) live in /config/state/ and are
+# created automatically; no manual setup required.
+scheduling:
+  # Skip this run if the previous run finished within this many minutes.
+  # 0 = disabled (always run). Set to e.g. 50 when a monthly cron and a
+  # manual trigger could fire within the same hour — only the first run
+  # executes, the second exits quietly with code 6 (SKIPPED_RECENT).
+  skip_if_run_within_minutes: 0

--- a/tier.py
+++ b/tier.py
@@ -3405,7 +3405,7 @@ def _check_skip_recent(cfg: dict) -> bool:
         finished_at = datetime.fromisoformat(finished_str)
         elapsed_min = (datetime.now(timezone.utc) - finished_at).total_seconds() / 60
         if elapsed_min < threshold:
-            log.info(
+            log.warning(
                 "Skipping run — last run finished %.1f min ago (threshold: %d min)",
                 elapsed_min, threshold,
             )

--- a/tier.py
+++ b/tier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-tier.py — Unraid media tiering script (Phase P3.5)
+tier.py — Unraid media tiering script (Phase P4.1)
 
 Pulls watch history and metadata from Plex, computes a heat score per
 media item (movies + TV series), probes the filesystem to determine
@@ -51,8 +51,10 @@ Phase status:
                     moves.max_total_move_gb has been successfully
                     transferred the move pass stops; remaining items
                     keep their scoring outcomes and retry next run.
-  P4  (later)       Scheduling primitives — lock file, structured exit
-                    codes, cron docs.
+  P4.1 (done)       Scheduling primitives — single-instance lock with
+                    stale-PID reclaim, persisted run-state (last_run.json),
+                    skip_if_run_within_minutes recency guard, formalised
+                    exit-code contract.
 
 Usage:
     tier.py [--config PATH] [--library NAME ...] [--json|--csv PATH]
@@ -60,9 +62,11 @@ Usage:
 
 Exit codes:
     0  success
-    1  configuration error
+    1  configuration error (file missing, token placeholder, empty libraries)
     2  Plex unreachable or auth failed
-    4  unhandled runtime error (notification fired if configured)
+    4  unhandled runtime error (error notification fired if configured)
+    5  lock held — another tier.py instance is already running
+    6  skipped — previous run finished within skip_if_run_within_minutes
   130  interrupted (SIGINT)
 """
 
@@ -70,6 +74,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import enum
 import glob
 import json
 import logging
@@ -103,6 +108,16 @@ except ImportError:
 
 # Module-level logger; configured by setup_logging().
 log = logging.getLogger("tier")
+
+
+class ExitCode(enum.IntEnum):
+    SUCCESS = 0
+    FATAL_CONFIG = 1       # config file missing/invalid (string sys.exit)
+    PLEX_ERROR = 2         # Plex unreachable or auth failed
+    UNHANDLED_CRASH = 4    # unhandled exception; error notifier fires
+    LOCK_HELD = 5          # another instance is running; do not notify
+    SKIPPED_RECENT = 6     # recency guard fired; do not notify
+    KEYBOARD_INTERRUPT = 130
 
 
 # ---------- Defaults (overridable via tiering.yaml) ----------
@@ -269,11 +284,20 @@ DEFAULT_CONFIG = {
         # statvfs.free is used as the match heuristic.
         "unraid_pool_name": None,
     },
+    # Scheduling primitives (P4.1).
+    "scheduling": {
+        # Skip this run if the previous run finished within this many minutes.
+        # 0 = disabled. Useful when multiple triggers (cron + manual) can fire
+        # close together and you only want one run per window.
+        "skip_if_run_within_minutes": 0,
+    },
 }
 
 # Default config path — container layout. Bare installs fall back to the
 # legacy /boot path in load_config().
 DEFAULT_CONFIG_PATH = Path("/config/tiering.yaml")
+# All scheduling state (lock file, last_run.json) lives here.
+_STATE_DIR = Path("/config/state")
 LEGACY_CONFIG_PATH = Path(
     "/boot/config/plugins/user.scripts/scripts/plex-media-tiering/tiering.yaml"
 )
@@ -597,7 +621,7 @@ def connect_plex(url: str, token: str, notifier: Notifier, ncfg: dict) -> PlexSe
                 ),
                 level="error",
             )
-        sys.exit(2)
+        sys.exit(int(ExitCode.PLEX_ERROR))
     except (ReqConnErr, BadRequest, TimeoutError) as e:
         log.error("Cannot reach Plex at %s: %s", url, e)
         if ncfg.get("on_plex_unreachable", True):
@@ -609,7 +633,7 @@ def connect_plex(url: str, token: str, notifier: Notifier, ncfg: dict) -> PlexSe
                 ),
                 level="error",
             )
-        sys.exit(2)
+        sys.exit(int(ExitCode.PLEX_ERROR))
 
 
 # ---------- Filesystem / tier detection (P1) ----------
@@ -2713,7 +2737,7 @@ def _apply_capacity_budget(
                 log.warning("Capacity: warm disk %s — could not read usage", disk)
 
 
-def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
+def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> dict:
     """Dry-run or execute moves for TO_HOT, TO_WARM, and RELOCATE_WARM outcomes.
 
     When apply=False: emits [DRY-RUN] log lines for every projected move.
@@ -2721,10 +2745,12 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
                       deletes the source after successful verification.
 
     Skips the entire pass if moves.enabled is false in config.
+    Returns a dict with moves_attempted, moves_succeeded, bytes_moved.
     """
+    _empty_stats: dict = {"moves_attempted": 0, "moves_succeeded": 0, "bytes_moved": 0}
     moves_cfg = cfg.get("moves") or {}
     if not moves_cfg.get("enabled"):
-        return
+        return _empty_stats
 
     hot_mount = (cfg.get("paths") or {}).get("hot_pool_mount") or ""
     if not hot_mount:
@@ -3028,6 +3054,12 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> None:
             ", ".join(sorted(hot_libraries)),
         )
 
+    return {
+        "moves_attempted": n_success + n_failed,
+        "moves_succeeded": n_success,
+        "bytes_moved": int(moved_bytes),
+    }
+
 
 # Outcomes that map to each projected tier if every recommendation were
 # executed. The bucket reflects where the item will END UP, not where it
@@ -3268,7 +3300,115 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _run(args) -> int:
+# ---------- Scheduling primitives (P4.1) ----------
+
+_LOCK_FILE = _STATE_DIR / "tier.lock"
+_LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+
+
+def _ensure_state_dir() -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _acquire_lock() -> bool:
+    """Acquire the single-instance lock. Returns True if acquired, False if held.
+
+    Lock file contents: {"pid": int, "started_at": ISO8601, "mode": str}.
+    A stale lock (referencing a dead PID) is reclaimed automatically.
+
+    Container PID-reuse guard: Docker one-shot containers always get PID 1
+    for the entrypoint process. If a previous container crashed without
+    releasing the lock, the next container also gets PID 1, so os.kill(1, 0)
+    succeeds (we ARE PID 1). We detect this by checking pid == os.getpid()
+    — no live process can hold a lock against itself at startup.
+    """
+    if _LOCK_FILE.exists():
+        try:
+            data = json.loads(_LOCK_FILE.read_text())
+            pid = int(data.get("pid") or 0)
+            if pid > 0:
+                if pid == os.getpid():
+                    # Our own PID is in the lock file — must be a stale lock
+                    # from a prior container run that reused this PID.
+                    log.warning("Reclaiming stale lock: PID %d matches our own PID (container restart)", pid)
+                else:
+                    try:
+                        os.kill(pid, 0)
+                        # No exception → process exists → genuine concurrent run.
+                        log.error(
+                            "Lock held by PID %d (started %s) — another tier.py instance is running",
+                            pid, data.get("started_at", "?"),
+                        )
+                        return False
+                    except ProcessLookupError:
+                        log.warning("Reclaiming stale lock from dead PID %d", pid)
+                    except PermissionError:
+                        # EPERM: process exists but we cannot signal it — treat as held.
+                        log.error(
+                            "Lock held by PID %d (started %s) — cannot verify (EPERM); "
+                            "remove %s manually if the process is dead",
+                            pid, data.get("started_at", "?"), _LOCK_FILE,
+                        )
+                        return False
+        except Exception as e:  # noqa: BLE001
+            log.warning("Could not read lock file — assuming stale, reclaiming: %s", e)
+
+    _LOCK_FILE.write_text(json.dumps({
+        "pid": os.getpid(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "mode": "full",
+    }))
+    return True
+
+
+def _release_lock() -> None:
+    try:
+        _LOCK_FILE.unlink(missing_ok=True)
+    except Exception as e:  # noqa: BLE001
+        log.warning("Could not release lock file: %s", e)
+
+
+def _check_skip_recent(cfg: dict) -> bool:
+    """Return True if this run should be skipped due to the recency guard."""
+    threshold = int((cfg.get("scheduling") or {}).get("skip_if_run_within_minutes") or 0)
+    if threshold <= 0:
+        return False
+    if not _LAST_RUN_FILE.exists():
+        return False
+    try:
+        data = json.loads(_LAST_RUN_FILE.read_text())
+        finished_str = data.get("finished_at")
+        if not finished_str:
+            return False
+        finished_at = datetime.fromisoformat(finished_str)
+        elapsed_min = (datetime.now(timezone.utc) - finished_at).total_seconds() / 60
+        if elapsed_min < threshold:
+            log.info(
+                "Skipping run — last run finished %.1f min ago (threshold: %d min)",
+                elapsed_min, threshold,
+            )
+            return True
+    except Exception as e:  # noqa: BLE001
+        log.warning("Could not read last_run.json for recency check: %s", e)
+    return False
+
+
+def _write_last_run(started_at: datetime, exit_code: int, move_stats: dict) -> None:
+    try:
+        _LAST_RUN_FILE.write_text(json.dumps({
+            "started_at": started_at.isoformat(),
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "full",
+            "exit_code": exit_code,
+            "moves_attempted": move_stats.get("moves_attempted", 0),
+            "moves_succeeded": move_stats.get("moves_succeeded", 0),
+            "bytes_moved": move_stats.get("bytes_moved", 0),
+        }, indent=2))
+    except Exception as e:  # noqa: BLE001
+        log.warning("Could not write last_run.json: %s", e)
+
+
+def _run(args) -> dict:
     """Inner main: wired up after logging + notifier are ready."""
     cfg = load_config(args.config)
 
@@ -3300,7 +3440,7 @@ def _run(args) -> int:
     # Move pass runs on the full scored list before --top truncation so every
     # TO_HOT item is considered regardless of display limit.
     moves_apply = args.apply or bool((cfg.get("moves") or {}).get("apply", False))
-    _run_move_pass(items, cfg, apply=moves_apply)
+    move_stats = _run_move_pass(items, cfg, apply=moves_apply)
 
     if args.top:
         items = items[: args.top]
@@ -3311,7 +3451,7 @@ def _run(args) -> int:
 
     if args.explain:
         explain_one(items, args.explain, cfg["thresholds"])
-        return 0
+        return move_stats
 
     if args.json:
         print(format_json(items))
@@ -3363,16 +3503,16 @@ def _run(args) -> int:
             )
             log.info("  Auto-inherit promotions: %d items", ai_promotions)
 
-    return 0
+    return move_stats
 
 
 def main() -> int:
     args = build_parser().parse_args()
 
-    # Outer try/except catches anything _run() didn't handle and alerts.
-    # We need a notifier to alert with, but building one needs the config;
-    # if the config itself blows up we fall back to stderr only.
+    # Load config early to build notifier and read scheduling settings.
+    # If the config itself blows up we fall back to stderr-only notifications.
     notifier: Optional[Notifier] = None
+    cfg_preview: Optional[dict] = None
     on_script_error = True
     try:
         try:
@@ -3389,27 +3529,53 @@ def main() -> int:
         except Exception:  # noqa: BLE001
             notifier = CompositeNotifier([StderrNotifier()])
 
-        return _run(args)
+        # Scheduling primitives — run before any Plex connection.
+        # LOCK_HELD and SKIPPED_RECENT are expected scheduler outcomes:
+        # they do not notify and do not write last_run.json.
+        _ensure_state_dir()
+        if not _acquire_lock():
+            return int(ExitCode.LOCK_HELD)
+
+        try:
+            if cfg_preview and _check_skip_recent(cfg_preview):
+                return int(ExitCode.SKIPPED_RECENT)
+
+            started_at = datetime.now(timezone.utc)
+            exit_code = ExitCode.SUCCESS
+            move_stats: dict = {"moves_attempted": 0, "moves_succeeded": 0, "bytes_moved": 0}
+
+            try:
+                move_stats = _run(args)
+                _write_last_run(started_at, int(ExitCode.SUCCESS), move_stats)
+            except SystemExit:
+                raise
+            except KeyboardInterrupt:
+                log.warning("Interrupted by user")
+                _write_last_run(started_at, int(ExitCode.KEYBOARD_INTERRUPT), move_stats)
+                exit_code = ExitCode.KEYBOARD_INTERRUPT
+            except Exception as e:  # noqa: BLE001
+                tb = traceback.format_exc()
+                log.error("Unhandled error: %s\n%s", e, tb)
+                if notifier is None:
+                    notifier = CompositeNotifier([StderrNotifier()])
+                if on_script_error:
+                    notifier.alert(
+                        title="Tier: script error",
+                        message=(
+                            f"tier.py crashed with: {type(e).__name__}: {e}\n\n"
+                            f"Tail of traceback:\n{tb[-800:]}"
+                        ),
+                        level="error",
+                    )
+                _write_last_run(started_at, int(ExitCode.UNHANDLED_CRASH), move_stats)
+                exit_code = ExitCode.UNHANDLED_CRASH
+
+            return int(exit_code)
+        finally:
+            _release_lock()
+
     except SystemExit:
         raise
-    except KeyboardInterrupt:
-        log.warning("Interrupted by user")
-        return 130
-    except Exception as e:  # noqa: BLE001
-        tb = traceback.format_exc()
-        log.error("Unhandled error: %s\n%s", e, tb)
-        if notifier is None:
-            notifier = CompositeNotifier([StderrNotifier()])
-        if on_script_error:
-            notifier.alert(
-                title="Tier: script error",
-                message=(
-                    f"tier.py crashed with: {type(e).__name__}: {e}\n\n"
-                    f"Tail of traceback:\n{tb[-800:]}"
-                ),
-                level="error",
-            )
-        return 4
 
 
 def _test_resolve_user_share():
@@ -5989,6 +6155,198 @@ def _test_capacity_unraid_api_not_configured_no_warn():
     print("_test_capacity_unraid_api_not_configured_no_warn: OK")
 
 
+def _test_lock_blocks_second_instance():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            # Use parent PID — a different live process, so os.kill succeeds
+            # and the lock is correctly treated as held (not stale, not self).
+            _LOCK_FILE.write_text(json.dumps({
+                "pid": os.getppid(),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "mode": "full",
+            }))
+            result = _acquire_lock()
+            assert result is False, f"expected False (lock held), got {result}"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_lock_blocks_second_instance: OK")
+
+
+def _test_lock_own_pid_reclaimed_as_stale():
+    """Lock file holds our own PID (container restart reuse) — reclaimed, not blocked."""
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            _LOCK_FILE.write_text(json.dumps({
+                "pid": os.getpid(),  # same as our own PID — simulates container PID reuse
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "mode": "full",
+            }))
+            result = _acquire_lock()
+            assert result is True, f"expected True (own PID treated as stale), got {result}"
+            data = json.loads(_LOCK_FILE.read_text())
+            assert data["pid"] == os.getpid(), "lock file should hold current PID after reclaim"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_lock_own_pid_reclaimed_as_stale: OK")
+
+
+def _test_lock_stale_pid_reclaimed():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            # PID 999999999 almost certainly does not exist.
+            _LOCK_FILE.write_text(json.dumps({
+                "pid": 999999999,
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "mode": "full",
+            }))
+            result = _acquire_lock()
+            assert result is True, f"expected True (stale lock reclaimed), got {result}"
+            data = json.loads(_LOCK_FILE.read_text())
+            assert data["pid"] == os.getpid(), "lock file should hold current PID after reclaim"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_lock_stale_pid_reclaimed: OK")
+
+
+def _test_lock_released_on_success():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            ok = _acquire_lock()
+            assert ok, "failed to acquire lock in test setup"
+            assert _LOCK_FILE.exists(), "lock file should exist after acquire"
+            _release_lock()
+            assert not _LOCK_FILE.exists(), "lock file should be gone after release"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_lock_released_on_success: OK")
+
+
+def _test_lock_released_on_failure():
+    """Lock acquired, simulated exception mid-run — lock still released via finally."""
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            ok = _acquire_lock()
+            assert ok
+            try:
+                raise RuntimeError("simulated mid-run failure")
+            finally:
+                _release_lock()
+            # unreachable, but the finally above must have run
+    except RuntimeError:
+        pass  # expected
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    # After the test, the real lock path is restored; the temp lock is gone.
+    print("_test_lock_released_on_failure: OK")
+
+
+def _test_skip_if_run_within_minutes():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            # Write last_run.json with finished_at 5 minutes ago.
+            finished = datetime.now(timezone.utc) - timedelta(minutes=5)
+            _LAST_RUN_FILE.write_text(json.dumps({
+                "started_at": (finished - timedelta(minutes=10)).isoformat(),
+                "finished_at": finished.isoformat(),
+                "mode": "full",
+                "exit_code": 0,
+                "moves_attempted": 0,
+                "moves_succeeded": 0,
+                "bytes_moved": 0,
+            }))
+            cfg = {"scheduling": {"skip_if_run_within_minutes": 30}}
+            result = _check_skip_recent(cfg)
+            assert result is True, f"expected True (within threshold), got {result}"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_skip_if_run_within_minutes: OK")
+
+
+def _test_skip_disabled_when_zero():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            finished = datetime.now(timezone.utc) - timedelta(minutes=1)
+            _LAST_RUN_FILE.write_text(json.dumps({
+                "finished_at": finished.isoformat(),
+                "mode": "full", "exit_code": 0,
+                "moves_attempted": 0, "moves_succeeded": 0, "bytes_moved": 0,
+            }))
+            cfg = {"scheduling": {"skip_if_run_within_minutes": 0}}
+            result = _check_skip_recent(cfg)
+            assert result is False, f"expected False (disabled), got {result}"
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_skip_disabled_when_zero: OK")
+
+
+def _test_last_run_written():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            started = datetime(2026, 5, 21, 3, 0, 0, tzinfo=timezone.utc)
+            stats = {"moves_attempted": 3, "moves_succeeded": 2, "bytes_moved": 1024}
+            _write_last_run(started, int(ExitCode.SUCCESS), stats)
+            assert _LAST_RUN_FILE.exists(), "last_run.json should exist"
+            data = json.loads(_LAST_RUN_FILE.read_text())
+            assert data["mode"] == "full"
+            assert data["exit_code"] == 0
+            assert data["moves_attempted"] == 3
+            assert data["moves_succeeded"] == 2
+            assert data["bytes_moved"] == 1024
+            assert data["started_at"].startswith("2026-05-21T03:00:00")
+            assert "finished_at" in data
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_last_run_written: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -6066,5 +6424,13 @@ if __name__ == "__main__":
         _test_run_cap_exact_boundary()
         _test_capacity_unraid_api_failure_warns_and_falls_back()
         _test_capacity_unraid_api_not_configured_no_warn()
-        sys.exit(0)
+        _test_lock_blocks_second_instance()
+        _test_lock_own_pid_reclaimed_as_stale()
+        _test_lock_stale_pid_reclaimed()
+        _test_lock_released_on_success()
+        _test_lock_released_on_failure()
+        _test_skip_if_run_within_minutes()
+        _test_skip_disabled_when_zero()
+        _test_last_run_written()
+        sys.exit(int(ExitCode.SUCCESS))
     sys.exit(main())

--- a/tier.py
+++ b/tier.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 import argparse
 import csv
 import enum
+import fcntl
 import glob
 import json
 import logging
@@ -2755,7 +2756,7 @@ def _run_move_pass(items: List["Item"], cfg: dict, apply: bool) -> dict:
     hot_mount = (cfg.get("paths") or {}).get("hot_pool_mount") or ""
     if not hot_mount:
         log.warning("Moves: moves.enabled=true but paths.hot_pool_mount not set — skipping")
-        return
+        return _empty_stats
 
     array_disks = resolve_array_disks(cfg)
 
@@ -3304,6 +3305,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 _LOCK_FILE = _STATE_DIR / "tier.lock"
 _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+# Open file handle kept alive while the flock is held; None when not locked.
+_lock_fh: Optional[object] = None
 
 
 def _ensure_state_dir() -> None:
@@ -3311,61 +3314,80 @@ def _ensure_state_dir() -> None:
 
 
 def _acquire_lock() -> bool:
-    """Acquire the single-instance lock. Returns True if acquired, False if held.
+    """Acquire a kernel-level exclusive advisory lock via fcntl.flock.
 
-    Lock file contents: {"pid": int, "started_at": ISO8601, "mode": str}.
-    A stale lock (referencing a dead PID) is reclaimed automatically.
+    Uses fcntl.flock(LOCK_EX|LOCK_NB) rather than a PID-liveness check.
+    This is correct across separate Docker containers: each container has
+    its own PID namespace, so os.kill() cannot see another container's
+    process and would wrongly reclaim a live lock.  flock() operates at
+    the kernel VFS layer — /config is a bind-mount of a host-local directory,
+    so the lock is shared by every container that mounts the same host path.
+    The kernel releases the lock automatically when the process or container
+    dies, so stale-lock cleanup is implicit and needs no PID inspection.
 
-    Container PID-reuse guard: Docker one-shot containers always get PID 1
-    for the entrypoint process. If a previous container crashed without
-    releasing the lock, the next container also gets PID 1, so os.kill(1, 0)
-    succeeds (we ARE PID 1). We detect this by checking pid == os.getpid()
-    — no live process can hold a lock against itself at startup.
+    Lock file also stores JSON metadata (pid, started_at, mode) so operators
+    can inspect who holds the lock, but that metadata is informational only.
     """
+    global _lock_fh
+
+    # Snapshot any existing metadata before we (possibly) truncate the file,
+    # so we can log who currently holds the lock on conflict.
+    existing: dict = {}
     if _LOCK_FILE.exists():
         try:
-            data = json.loads(_LOCK_FILE.read_text())
-            pid = int(data.get("pid") or 0)
-            if pid > 0:
-                if pid == os.getpid():
-                    # Our own PID is in the lock file — must be a stale lock
-                    # from a prior container run that reused this PID.
-                    log.warning("Reclaiming stale lock: PID %d matches our own PID (container restart)", pid)
-                else:
-                    try:
-                        os.kill(pid, 0)
-                        # No exception → process exists → genuine concurrent run.
-                        log.error(
-                            "Lock held by PID %d (started %s) — another tier.py instance is running",
-                            pid, data.get("started_at", "?"),
-                        )
-                        return False
-                    except ProcessLookupError:
-                        log.warning("Reclaiming stale lock from dead PID %d", pid)
-                    except PermissionError:
-                        # EPERM: process exists but we cannot signal it — treat as held.
-                        log.error(
-                            "Lock held by PID %d (started %s) — cannot verify (EPERM); "
-                            "remove %s manually if the process is dead",
-                            pid, data.get("started_at", "?"), _LOCK_FILE,
-                        )
-                        return False
-        except Exception as e:  # noqa: BLE001
-            log.warning("Could not read lock file — assuming stale, reclaiming: %s", e)
+            existing = json.loads(_LOCK_FILE.read_text())
+        except Exception:  # noqa: BLE001
+            pass
 
-    _LOCK_FILE.write_text(json.dumps({
-        "pid": os.getpid(),
-        "started_at": datetime.now(timezone.utc).isoformat(),
-        "mode": "full",
-    }))
+    try:
+        fh = open(_LOCK_FILE, "w")  # noqa: WPS515 — intentionally kept open
+    except OSError as e:
+        log.warning("Could not open lock file %s: %s — proceeding without lock", _LOCK_FILE, e)
+        return True
+
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        fh.close()
+        log.error(
+            "Lock held (started %s) — another tier.py instance is running",
+            existing.get("started_at", "?"),
+        )
+        return False
+    except Exception as e:  # noqa: BLE001
+        fh.close()
+        log.warning("flock failed: %s — proceeding without lock", e)
+        return True
+
+    # Lock acquired — write metadata and keep the handle open.
+    try:
+        fh.write(json.dumps({
+            "pid": os.getpid(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "full",
+        }))
+        fh.flush()
+    except Exception as e:  # noqa: BLE001
+        log.warning("Could not write lock metadata: %s", e)
+
+    _lock_fh = fh
     return True
 
 
 def _release_lock() -> None:
+    global _lock_fh
+    if _lock_fh is not None:
+        try:
+            fcntl.flock(_lock_fh, fcntl.LOCK_UN)
+            _lock_fh.close()
+        except Exception as e:  # noqa: BLE001
+            log.warning("Could not release lock: %s", e)
+        finally:
+            _lock_fh = None
     try:
         _LOCK_FILE.unlink(missing_ok=True)
     except Exception as e:  # noqa: BLE001
-        log.warning("Could not release lock file: %s", e)
+        log.warning("Could not remove lock file: %s", e)
 
 
 def _check_skip_recent(cfg: dict) -> bool:
@@ -6156,117 +6178,108 @@ def _test_capacity_unraid_api_not_configured_no_warn():
 
 
 def _test_lock_blocks_second_instance():
+    """flock held by another fd → _acquire_lock returns False (BlockingIOError)."""
     import tempfile as _tf
-    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
+    orig_state, orig_lock, orig_last, orig_fh = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
     try:
         with _tf.TemporaryDirectory() as tmp:
             _STATE_DIR = Path(tmp)
             _LOCK_FILE = _STATE_DIR / "tier.lock"
             _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
-            # Use parent PID — a different live process, so os.kill succeeds
-            # and the lock is correctly treated as held (not stale, not self).
-            _LOCK_FILE.write_text(json.dumps({
-                "pid": os.getppid(),
-                "started_at": datetime.now(timezone.utc).isoformat(),
-                "mode": "full",
-            }))
-            result = _acquire_lock()
-            assert result is False, f"expected False (lock held), got {result}"
+            _lock_fh = None
+            # Simulate another instance: open the file and hold LOCK_EX.
+            # flock on the same inode from a second fd (the one _acquire_lock
+            # will open) will block — LOCK_NB turns that into BlockingIOError.
+            holder = open(_LOCK_FILE, "w")
+            holder.write(json.dumps({"started_at": "2026-01-01T00:00:00+00:00"}))
+            holder.flush()
+            fcntl.flock(holder, fcntl.LOCK_EX)
+            try:
+                result = _acquire_lock()
+                assert result is False, f"expected False (flock held), got {result}"
+                assert _lock_fh is None, "_lock_fh must stay None when acquire fails"
+            finally:
+                fcntl.flock(holder, fcntl.LOCK_UN)
+                holder.close()
     finally:
-        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh = orig_state, orig_lock, orig_last, orig_fh
     print("_test_lock_blocks_second_instance: OK")
 
 
-def _test_lock_own_pid_reclaimed_as_stale():
-    """Lock file holds our own PID (container restart reuse) — reclaimed, not blocked."""
+def _test_lock_stale_file_acquired():
+    """Lock file exists but no flock held (crashed prior run) → acquired cleanly."""
     import tempfile as _tf
-    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
+    orig_state, orig_lock, orig_last, orig_fh = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
     try:
         with _tf.TemporaryDirectory() as tmp:
             _STATE_DIR = Path(tmp)
             _LOCK_FILE = _STATE_DIR / "tier.lock"
             _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
-            _LOCK_FILE.write_text(json.dumps({
-                "pid": os.getpid(),  # same as our own PID — simulates container PID reuse
-                "started_at": datetime.now(timezone.utc).isoformat(),
-                "mode": "full",
-            }))
-            result = _acquire_lock()
-            assert result is True, f"expected True (own PID treated as stale), got {result}"
-            data = json.loads(_LOCK_FILE.read_text())
-            assert data["pid"] == os.getpid(), "lock file should hold current PID after reclaim"
-    finally:
-        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
-    print("_test_lock_own_pid_reclaimed_as_stale: OK")
-
-
-def _test_lock_stale_pid_reclaimed():
-    import tempfile as _tf
-    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    try:
-        with _tf.TemporaryDirectory() as tmp:
-            _STATE_DIR = Path(tmp)
-            _LOCK_FILE = _STATE_DIR / "tier.lock"
-            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
-            # PID 999999999 almost certainly does not exist.
+            _lock_fh = None
+            # Write stale metadata — no process holds a flock on this file.
             _LOCK_FILE.write_text(json.dumps({
                 "pid": 999999999,
-                "started_at": datetime.now(timezone.utc).isoformat(),
+                "started_at": "2026-01-01T00:00:00+00:00",
                 "mode": "full",
             }))
             result = _acquire_lock()
-            assert result is True, f"expected True (stale lock reclaimed), got {result}"
-            data = json.loads(_LOCK_FILE.read_text())
-            assert data["pid"] == os.getpid(), "lock file should hold current PID after reclaim"
+            assert result is True, f"expected True (no flock held), got {result}"
+            assert _lock_fh is not None, "_lock_fh should be set after successful acquire"
+            _release_lock()
     finally:
-        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
-    print("_test_lock_stale_pid_reclaimed: OK")
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh = orig_state, orig_lock, orig_last, orig_fh
+    print("_test_lock_stale_file_acquired: OK")
 
 
 def _test_lock_released_on_success():
+    """After _release_lock, the file is gone and the flock is freed."""
     import tempfile as _tf
-    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
+    orig_state, orig_lock, orig_last, orig_fh = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
     try:
         with _tf.TemporaryDirectory() as tmp:
             _STATE_DIR = Path(tmp)
             _LOCK_FILE = _STATE_DIR / "tier.lock"
             _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            _lock_fh = None
             ok = _acquire_lock()
             assert ok, "failed to acquire lock in test setup"
             assert _LOCK_FILE.exists(), "lock file should exist after acquire"
             _release_lock()
             assert not _LOCK_FILE.exists(), "lock file should be gone after release"
+            assert _lock_fh is None, "_lock_fh should be None after release"
+            # Verify the flock is actually free: we can re-acquire immediately.
+            ok2 = _acquire_lock()
+            assert ok2, "should be able to re-acquire after release"
+            _release_lock()
     finally:
-        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh = orig_state, orig_lock, orig_last, orig_fh
     print("_test_lock_released_on_success: OK")
 
 
 def _test_lock_released_on_failure():
     """Lock acquired, simulated exception mid-run — lock still released via finally."""
     import tempfile as _tf
-    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
-    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
+    orig_state, orig_lock, orig_last, orig_fh = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh
     try:
         with _tf.TemporaryDirectory() as tmp:
             _STATE_DIR = Path(tmp)
             _LOCK_FILE = _STATE_DIR / "tier.lock"
             _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            _lock_fh = None
             ok = _acquire_lock()
             assert ok
             try:
                 raise RuntimeError("simulated mid-run failure")
             finally:
                 _release_lock()
-            # unreachable, but the finally above must have run
     except RuntimeError:
         pass  # expected
     finally:
-        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
-    # After the test, the real lock path is restored; the temp lock is gone.
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE, _lock_fh = orig_state, orig_lock, orig_last, orig_fh
     print("_test_lock_released_on_failure: OK")
 
 
@@ -6425,8 +6438,7 @@ if __name__ == "__main__":
         _test_capacity_unraid_api_failure_warns_and_falls_back()
         _test_capacity_unraid_api_not_configured_no_warn()
         _test_lock_blocks_second_instance()
-        _test_lock_own_pid_reclaimed_as_stale()
-        _test_lock_stale_pid_reclaimed()
+        _test_lock_stale_file_acquired()
         _test_lock_released_on_success()
         _test_lock_released_on_failure()
         _test_skip_if_run_within_minutes()

--- a/tier.py
+++ b/tier.py
@@ -3416,6 +3416,7 @@ def _check_skip_recent(cfg: dict) -> bool:
 
 
 def _write_last_run(started_at: datetime, exit_code: int, move_stats: dict) -> None:
+    move_stats = move_stats or {}
     try:
         _LAST_RUN_FILE.write_text(json.dumps({
             "started_at": started_at.isoformat(),
@@ -3567,7 +3568,7 @@ def main() -> int:
             move_stats: dict = {"moves_attempted": 0, "moves_succeeded": 0, "bytes_moved": 0}
 
             try:
-                move_stats = _run(args)
+                move_stats = _run(args) or move_stats
                 _write_last_run(started_at, int(ExitCode.SUCCESS), move_stats)
             except SystemExit:
                 raise
@@ -6360,6 +6361,30 @@ def _test_last_run_written():
     print("_test_last_run_written: OK")
 
 
+def _test_last_run_written_when_run_returns_none():
+    import tempfile as _tf
+    global _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    orig_state, orig_lock, orig_last = _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE
+    try:
+        with _tf.TemporaryDirectory() as tmp:
+            _STATE_DIR = Path(tmp)
+            _LOCK_FILE = _STATE_DIR / "tier.lock"
+            _LAST_RUN_FILE = _STATE_DIR / "last_run.json"
+            started = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+            # Simulate _run() returning None (dry-run path).
+            _write_last_run(started, int(ExitCode.SUCCESS), None)
+            assert _LAST_RUN_FILE.exists(), "last_run.json should exist even when move_stats is None"
+            data = json.loads(_LAST_RUN_FILE.read_text())
+            assert data["exit_code"] == 0
+            assert data["moves_attempted"] == 0
+            assert data["moves_succeeded"] == 0
+            assert data["bytes_moved"] == 0
+            assert "finished_at" in data
+    finally:
+        _STATE_DIR, _LOCK_FILE, _LAST_RUN_FILE = orig_state, orig_lock, orig_last
+    print("_test_last_run_written_when_run_returns_none: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -6444,5 +6469,6 @@ if __name__ == "__main__":
         _test_skip_if_run_within_minutes()
         _test_skip_disabled_when_zero()
         _test_last_run_written()
+        _test_last_run_written_when_run_returns_none()
         sys.exit(int(ExitCode.SUCCESS))
     sys.exit(main())


### PR DESCRIPTION
## Summary

P4.1 adds scheduling safety primitives so tier.py can run safely from a cron/Docker scheduler without needing an external orchestration layer:

- **Single-instance lock** (`/config/state/tier.lock`) — `fcntl.flock(LOCK_EX|LOCK_NB)` prevents concurrent runs across separate Docker containers sharing the same `/config` bind-mount. Auto-released by the kernel on container death; no stale-lock cleanup needed.
- **Persisted run state** (`/config/state/last_run.json`) — written after every completed run; records `started_at`, `finished_at`, exit code, and move stats.
- **Recency guard** (`skip_if_run_within_minutes`) — skips a run if a successful run finished within the configured window; useful when the Docker scheduler fires more frequently than you want the script to actually run.
- **Formalised exit-code contract** (`ExitCode` IntEnum) — callers and monitoring tools can now distinguish lock-held (5) and skipped-recent (6) from real errors.

## Note: rebased onto main after PR #25

This branch was rebased onto `main` after the dual-home networking fix (PR #25) merged. Both PR #25's two new capacity tests and P4.1's seven scheduling tests are included and pass.

## Config schema

```yaml
scheduling:
  skip_if_run_within_minutes: 0   # 0 = disabled; set e.g. 55 for hourly cron
```

## Behaviour

- Lock file is at `/config/state/tier.lock`; state dir is created on first use.
- `LOCK_HELD` (exit 5): another instance is running — no `last_run.json` written, error notifier NOT fired.
- `SKIPPED_RECENT` (exit 6): last run finished within `skip_if_run_within_minutes` — no `last_run.json` written, error notifier NOT fired.
- Lock is acquired before Plex connects; released in `finally` so a Plex error or keyboard interrupt still releases it.
- `fcntl.flock` works across separate Docker containers mounting the same host directory; PID-namespace isolation does not affect file-lock sharing.

## Exit-code contract

| Code | Name | Meaning |
| --- | --- | --- |
| 0 | SUCCESS | Run completed (dry-run or apply) |
| 1 | FATAL_CONFIG | Config missing/invalid |
| 2 | PLEX_ERROR | Cannot reach Plex |
| 4 | UNHANDLED_CRASH | Unexpected exception |
| 5 | LOCK_HELD | Another instance running |
| 6 | SKIPPED_RECENT | Within skip_if_run_within_minutes window |
| 130 | KEYBOARD_INTERRUPT | Ctrl-C |

## Tests

Seven new inline tests; all 79 tests pass:

- `_test_lock_blocks_second_instance` — flock on same file blocks a second acquire
- `_test_lock_stale_file_acquired` — orphaned lock file (no holder) is acquired cleanly
- `_test_lock_released_on_success` — lock file absent after normal release
- `_test_lock_released_on_failure` — lock released via `finally` even after mid-run exception
- `_test_skip_if_run_within_minutes` — returns True when last run is within threshold
- `_test_skip_disabled_when_zero` — returns False when threshold is 0
- `_test_last_run_written` — `last_run.json` contains correct fields after a run

## Docs

- `README.md`: new "Scheduling (P4.1)" section with cron example; exit-code table extended with codes 5 & 6; phase table updated.
- `AGENTS.md`: "Scheduling model (P4.1)" design section added; phase table updated; stale "lock file not yet implemented" note removed; full exit-code table added.
- `example.tiering.yaml`: `scheduling:` block added.

## Test plan

CI (`py_compile` + YAML + `--_test`) is sufficient for this change — all logic is pure Python with no Plex API calls or filesystem moves.

- [ ] Confirm CI passes on this PR
- [ ] Optional on-Unraid smoke test: run with `--_test`, then run twice in quick succession with `skip_if_run_within_minutes: 1` and confirm second run exits 6

Closes #24