### PR TITLE
fix(net/capacity): macvlan/ipvlan dual-home deployment guide + Unraid API fallback warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -775,6 +775,14 @@ Capacity: warm disk /mnt/disk2 — 7.6 / 8.0 TB (95%)  ← over 90% ceiling
 ```
 This replaces the previous "warm disks all under N% ceiling" summary line.
 
+## Deployment & networking
+
+### macvlan/ipvlan-L2 and the dual-home requirement
+
+When Plex runs on a macvlan or ipvlan-L2 Docker network and the tiering container also uses `capacity.unraid_api_url`, the container must be **dual-homed**: primary network `bridge` (keeps the default route to the Unraid host for the Connect API), plus a second interface on the macvlan/ipvlan network (connected route for the Plex subnet). A single macvlan/ipvlan interface cannot reach both Plex (child↔child, permitted) and the Unraid host (child↔host, blocked by macvlan/ipvlan-L2 kernel isolation) simultaneously.
+
+See the README "Deployment & networking" section for the full recipe, caveats, and the no-dual-home alternative (local capacity methods).
+
 ## Development rules
 
 ### Write only to `/config` at runtime

--- a/README.md
+++ b/README.md
@@ -139,6 +139,57 @@ manually revoke devices, or unlink the server. Keep `tiering.yaml` at
 **If the token goes stale:** the script detects it on connect and fires an
 alert (see Notifications below) so you're not flying blind.
 
+## Deployment & networking
+
+**The key question: can the tiering container reach Plex, and (if used) the Unraid Connect API?**
+
+### Simple case — Plex on the default bridge network
+
+No extra steps needed. The container connects to Plex over the bridge the same way any Docker container does.
+
+### Plex on a macvlan or ipvlan-L2 network (same Docker host)
+
+If Plex has its own VLAN via a macvlan or ipvlan-L2 Docker network, the default bridge container **cannot reach it**. macvlan/ipvlan-L2 enforces host-isolation: the Linux kernel blocks traffic between the host's bridge (`docker0`) and a macvlan/ipvlan child interface on the same parent. The symptom is:
+
+```
+ERROR Cannot reach Plex at http://192.0.2.10:32400: ConnectTimeoutError
+```
+
+**If you only need to reach Plex** (no `capacity.unraid_api_url`): put the tiering container on the **same** macvlan/ipvlan network as Plex. child↔child peer traffic is permitted and the timeout goes away.
+
+**If you also use `capacity.unraid_api_url`** (Unraid Connect API): the container must additionally reach the **Unraid host** — which a single macvlan/ipvlan interface *cannot* do (child↔host is blocked). Use the **dual-home** pattern instead:
+
+#### Dual-home recipe (bridge primary + macvlan/ipvlan secondary)
+
+1. Leave the template `<Network>bridge</Network>` unchanged. This keeps the default route via `docker0` so the Unraid host (Connect API, notifier) is reachable like any normal bridge container.
+
+2. After the container is created, attach a second interface on the macvlan/ipvlan network Plex is on:
+
+   ```sh
+   # Replace br0.X with your macvlan/ipvlan network name in Docker,
+   # and 192.0.2.32 with a free IP in that network's Docker IPAM range.
+   docker network connect --ip 192.0.2.32 br0.X plex-media-tiering
+   ```
+
+3. No `tiering.yaml` changes are needed. Linux routing picks the connected route for the Plex subnet (macvlan/ipvlan leg) and uses the bridge default route for everything else (Unraid host, internet).
+
+**Caveat:** this assumes the Unraid management/API IP is on a **different subnet/VLAN than Plex**. If both endpoints share the same VLAN, the Unraid API traffic also routes over the macvlan/ipvlan leg and hits the same host-isolation wall — use a local capacity method instead (see [Hot pool usage detection (ZFS)](#hot-pool-usage-detection-zfs)).
+
+#### Host-isolation affects two features
+
+When the tiering container is on a macvlan/ipvlan-L2 network without dual-homing, two features that call the **Unraid host** will silently degrade or fail:
+
+- **`capacity.unraid_api_url`** — falls back through the capacity chain (zpool → kstat → `hot_pool_total_gb` override → statvfs). A WARNING is logged so the degradation is visible.
+- **`notifications.unraid.enabled`** — the notify script bind-mount path (`/usr/local/emhttp/webGui/scripts/notify`) only exists if the host path is bind-mounted; if the macvlan container can't exec it, notifications fall back to other configured methods or are silently skipped.
+
+#### Avoiding dual-homing entirely
+
+Use a **local** capacity method that doesn't call the host — `zpool` in-container, the `/proc/spl` bind-mount, or `capacity.hot_pool_total_gb` override — then a single macvlan/ipvlan interface is sufficient and no dual-homing is required. See [Hot pool usage detection (ZFS)](#hot-pool-usage-detection-zfs) for setup instructions.
+
+#### Note on Unraid's "Host access to custom networks" toggle
+
+Unraid offers a toggle that lets the host reach containers on custom networks. Under **macvlan** it has a known kernel-panic history; **ipvlan-L2** is the safer mode if you use it. Dual-homing avoids any host-network change entirely and is the preferred approach.
+
 ## Docker Hub + GitHub Actions (publish pipeline)
 
 **Free-tier compatible.** Docker Hub free gives unlimited public repos;

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -289,6 +289,10 @@ capacity:
   # Get an API key: Unraid UI → Settings → Management Access → API Keys → New Key.
   # The URL is your Unraid host IP on port 80 (or 443 if HTTPS is enabled).
   # Advantage: fully automatic, no pool-name config needed in most cases.
+  # Network note: the tiering container must be able to reach the Unraid host to use
+  # this option. If Plex runs on a macvlan/ipvlan-L2 network, a single macvlan/ipvlan
+  # interface cannot reach the host. Use the dual-home pattern described in the README
+  # "Deployment & networking" section, or switch to Option B instead.
   unraid_api_url: null       # e.g. "https://192.168.1.100/graphql"  (must be https)
   unraid_api_key: null       # API key string from the Unraid UI
   unraid_pool_name: null     # ZFS pool name (e.g. "Zfs_media"); auto-matched if null

--- a/tier.py
+++ b/tier.py
@@ -2269,6 +2269,12 @@ def _pool_usage_bytes(
         if result is not None:
             log.debug("Capacity: hot pool via Unraid API: total=%d used=%d", *result)
             return result
+        log.warning(
+            "Capacity: Unraid Connect API (capacity.unraid_api_url) was configured but "
+            "returned no usable result — falling back to local detection "
+            "(zpool/kstat/override/statvfs). Tiering continues; see DEBUG for the API "
+            "failure detail."
+        )
 
     # --- Methods 2 & 3: zpool command / /proc/spl kstat ---
     pool_name = _zfs_pool_name_for_mount(mount)
@@ -5891,6 +5897,98 @@ def _test_run_cap_exact_boundary():
     print("_test_run_cap_exact_boundary: OK")
 
 
+def _test_capacity_unraid_api_failure_warns_and_falls_back():
+    """When unraid_api_url is set but _try_unraid_api returns None, a WARNING is emitted
+    and _pool_usage_bytes falls through to the override method."""
+    import logging
+    global _try_unraid_api, _disk_usage
+    orig_api = _try_unraid_api
+    orig_du = _disk_usage
+    captured = []
+
+    class _CapturingHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    handler = _CapturingHandler()
+    log.addHandler(handler)
+    try:
+        _try_unraid_api = lambda *_, **__: None  # noqa: E731
+
+        GB = 1024 ** 3
+        free_bytes = 60 * GB
+        total_override_gb = 100.0
+        _DU = type("DU", (), {"total": int(total_override_gb * GB), "used": 0, "free": free_bytes})()
+        _disk_usage = lambda *_: _DU  # noqa: E731
+
+        total, used = _pool_usage_bytes(
+            mount="/mnt/hot_pool",
+            total_gb_override=total_override_gb,
+            unraid_api_url="https://unraid.invalid/graphql",
+            unraid_api_key="dummy-key",
+        )
+
+        # (a) fell through to override: total = 100 GiB, used = total - free
+        expected_total = int(total_override_gb * GB)
+        expected_used = max(0, expected_total - free_bytes)
+        assert total == expected_total, f"expected total={expected_total}, got {total}"
+        assert used == expected_used, f"expected used={expected_used}, got {used}"
+
+        # (b) a WARNING containing "unraid_api_url" was emitted
+        warnings = [r for r in captured if r.levelno == logging.WARNING and "unraid_api_url" in r.getMessage()]
+        assert warnings, "expected a WARNING about Unraid API fallback, got none"
+    finally:
+        _try_unraid_api = orig_api
+        _disk_usage = orig_du
+        log.removeHandler(handler)
+
+    print("_test_capacity_unraid_api_failure_warns_and_falls_back: OK")
+
+
+def _test_capacity_unraid_api_not_configured_no_warn():
+    """When unraid_api_url is None, _try_unraid_api is never called and no WARNING fires."""
+    import logging
+    global _try_unraid_api, _disk_usage, _zfs_pool_name_for_mount
+    orig_api = _try_unraid_api
+    orig_du = _disk_usage
+    orig_pool = _zfs_pool_name_for_mount
+    captured = []
+    api_calls = []
+
+    class _CapturingHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    handler = _CapturingHandler()
+    log.addHandler(handler)
+    try:
+        def _spy_api(*_):
+            api_calls.append(1)
+            return None
+        _try_unraid_api = _spy_api
+        _zfs_pool_name_for_mount = lambda *_: None  # noqa: E731
+
+        GB = 1024 ** 3
+        _DU = type("DU", (), {"total": 100 * GB, "used": 40 * GB, "free": 60 * GB})()
+        _disk_usage = lambda *_: _DU  # noqa: E731
+
+        _pool_usage_bytes(mount="/mnt/hot_pool", unraid_api_url=None)
+
+        # _try_unraid_api must NOT have been called
+        assert not api_calls, f"_try_unraid_api should not be called when url is None, was called {len(api_calls)} times"
+
+        # No WARNING about Unraid API
+        warnings = [r for r in captured if r.levelno == logging.WARNING and "unraid_api_url" in r.getMessage()]
+        assert not warnings, f"expected no Unraid API warning, got: {[r.getMessage() for r in warnings]}"
+    finally:
+        _try_unraid_api = orig_api
+        _disk_usage = orig_du
+        _zfs_pool_name_for_mount = orig_pool
+        log.removeHandler(handler)
+
+    print("_test_capacity_unraid_api_not_configured_no_warn: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -5966,5 +6064,7 @@ if __name__ == "__main__":
         _test_run_cap_zero_disables_cap()
         _test_run_cap_counts_successful_moves_only()
         _test_run_cap_exact_boundary()
+        _test_capacity_unraid_api_failure_warns_and_falls_back()
+        _test_capacity_unraid_api_not_configured_no_warn()
         sys.exit(0)
     sys.exit(main())

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -48,6 +48,30 @@
   <DonateLink/>
   <Requires/>
 
+  <!--
+  NETWORKING — read this if Plex runs on a macvlan or ipvlan-L2 Docker network.
+
+  The default <Network>bridge</Network> lets the container reach the Unraid host
+  (needed for the Unraid Connect API capacity option and the Unraid notifier).
+  However, a bridge container CANNOT reach a container on a macvlan/ipvlan-L2
+  network on the same host — you will see ConnectTimeoutError trying to reach Plex.
+
+  Solution: keep bridge as the primary network (for host access), then attach a
+  second interface on the macvlan/ipvlan network Plex is on. Run this once after
+  the container is created (replace br0.X and the IP with your network name and a
+  free IP from its Docker IPAM range):
+
+    docker network connect --ip 192.0.2.32 br0.X plex-media-tiering
+
+  Why bridge stays primary: it keeps the default route via docker0 so the Unraid
+  host (Connect API, notifier) is reachable like any normal bridge container.
+  Why the macvlan/ipvlan leg is secondary: it adds a connected route for the Plex
+  subnet, letting the container reach Plex as a child-to-child peer (permitted).
+  No tiering.yaml changes are needed — routing is automatic once both interfaces exist.
+
+  See README "Deployment & networking" for the full guide, alternatives, and caveats.
+  -->
+
   <!-- Default command: read-only analysis. Edit to add "top 50" etc. for
        trimmed output. P2+ will add the apply flag (DO NOT set this until
        you have eyeballed a dry run). -->


### PR DESCRIPTION
## Summary

When Plex runs on a macvlan/ipvlan-L2 Docker network, the tiering container (on default `bridge`) times out connecting to Plex due to macvlan/ipvlan-L2 host-isolation. Deployments that also use `capacity.unraid_api_url` face a compounding problem: they must reach both Plex (a child-to-child peer) and the Unraid host (child-to-host, blocked by isolation) — opposite sides of the same boundary. This PR documents the dual-home deployment pattern and surfaces previously-silent capacity fallback degradation.

## Config schema

No new config keys. A one-line comment is added near `capacity.unraid_api_url` in `example.tiering.yaml` pointing to the new README section.

## Behaviour

- **README**: new `## Deployment & networking` section covering the macvlan/ipvlan timeout symptom, the dual-home recipe (bridge primary + macvlan/ipvlan secondary), caveats, the local-capacity alternative, and notes on Unraid's host-access shim.
- **`unraid-template.xml`**: added a prominent comment block with the `docker network connect` snippet and explanation of why bridge stays primary.
- **`example.tiering.yaml`**: one-line comment near `unraid_api_url` referencing the README networking section.
- **`AGENTS.md`**: short note under a new `## Deployment & networking` section summarising the dual-home requirement and linking the README.
- **`tier.py`** (only code change): in `_pool_usage_bytes()`, when `unraid_api_url` is configured but `_try_unraid_api()` returns `None`, emit a `log.warning(...)` before falling through to local detection. Control flow is unchanged — capacity stays non-fatal, Plex remains a hard stop.

## Tests

- `_test_capacity_unraid_api_failure_warns_and_falls_back` — patches `_try_unraid_api` to return `None`; asserts (a) correct override-derived result returned and (b) WARNING record emitted.
- `_test_capacity_unraid_api_not_configured_no_warn` — with `unraid_api_url=None`, asserts `_try_unraid_api` is not called and no WARNING is emitted.
- All existing tests pass unchanged.

## Docs

- README: new `## Deployment & networking` section added before `## Docker Hub + GitHub Actions`.
- AGENTS.md: new `## Deployment & networking` section added before `## Development rules`.
- `example.tiering.yaml`: inline comment added near `unraid_api_url`.
- `unraid-template.xml`: inline comment block added near `<Arguments>`.

## Test plan

- [x] `python3 -m py_compile tier.py` — passes
- [x] YAML validity check — passes
- [x] `python3 tier.py --_test` — all tests pass including two new ones

**No Unraid manual testing required** — the only code change is a single `log.warning()` call in the capacity fallback path; no Plex API semantics or real filesystem behaviour is touched.

## Merge order

This PR targets `main` and should merge **before** PR #23 (`feat/p4.1-scheduling-primitives`), which will then be rebased on top. The two branches do not overlap.

Closes #24