### PR TITLE
fix: parse grandparentKey path when grandparentRatingKey is absent in history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,30 @@ library keeps the response bounded and plexapi's pagination works.
 
 Global fallback sweep runs only if every per-section call returned zero.
 
+### `grandparentKey` path parsing in `_ingest_history`
+
+Plex's `/status/sessions/history` endpoint (used by plexapi's
+`plex.history()`) exposes episode events with `grandparentKey` in path
+form (`/library/metadata/<id>`) but **omits `grandparentRatingKey`** —
+it is always `None` on every episode event returned from this endpoint.
+
+Early code in `_ingest_history` tested `grandparentRatingKey is None`
+and skipped the show-level rollup for those events, so the index had
+per-episode entries only — no show-level aggregations. Every
+`collect_series` lookup on `show.ratingKey` missed, triggering the
+per-show fallback `show.history()` call for every series (~208 calls,
+~4 minutes of serial API traffic per run).
+
+Fix: `_parse_grandparent_id(h)` tries `grandparentRatingKey` first; on
+`None` it parses the trailing integer from `grandparentKey`
+(`/library/metadata/12345` → `12345`). Parse failures (non-integer tail,
+unexpected path shape, attribute absent) return `None` and the event is
+skipped cleanly. `_ingest_history` now calls this helper instead of
+checking `grandparentRatingKey` directly.
+
+The `_show_history_fallback` path is unchanged and still fires as a true
+last resort for shows that have genuine ratingKey drift after a rematch.
+
 ### Per-show history fallback for rematched shows
 
 After a Plex rematch or library move, history events can reference a

--- a/tier.py
+++ b/tier.py
@@ -1170,12 +1170,41 @@ def _clean_title(title: str, year: Optional[int]) -> str:
     return cleaned
 
 
+def _parse_grandparent_id(h) -> Optional[int]:
+    """Return the grandparent ratingKey int from a history event, or None.
+
+    The /status/sessions/history endpoint omits grandparentRatingKey on episode
+    events but always provides grandparentKey in path form (/library/metadata/<id>).
+    We try grandparentRatingKey first (direct int); on None we parse the trailing
+    integer from grandparentKey as the fallback.
+    """
+    grk = getattr(h, "grandparentRatingKey", None)
+    if grk is not None:
+        try:
+            return int(grk)
+        except (TypeError, ValueError):
+            pass
+
+    gk = getattr(h, "grandparentKey", None)
+    if gk is not None:
+        try:
+            tail = gk.rstrip("/").rsplit("/", 1)[-1]
+            return int(tail)
+        except (TypeError, ValueError, IndexError):
+            pass
+
+    return None
+
+
 def _ingest_history(events, index: dict) -> int:
     """Fold a sequence of History objects into the index. Returns event count.
 
     Each event contributes to:
-      - index[ratingKey]             (the movie OR episode itself)
-      - index[grandparentRatingKey]  (the show, for series rollup)
+      - index[ratingKey]    (the movie OR episode itself)
+      - index[grandparent]  (the show, for series rollup — resolved via
+                             grandparentRatingKey when present, or by parsing
+                             the trailing id from grandparentKey, because the
+                             history endpoint omits grandparentRatingKey)
     """
     count = 0
     for h in events:
@@ -1194,12 +1223,8 @@ def _ingest_history(events, index: dict) -> int:
         if viewed_at and (entry["last"] is None or viewed_at > entry["last"]):
             entry["last"] = viewed_at
 
-        grk = getattr(h, "grandparentRatingKey", None)
-        if grk is None:
-            continue
-        try:
-            grk_int = int(grk)
-        except (TypeError, ValueError):
+        grk_int = _parse_grandparent_id(h)
+        if grk_int is None:
             continue
         gentry = index.setdefault(grk_int, {"plays": 0, "last": None})
         gentry["plays"] += 1
@@ -6385,6 +6410,53 @@ def _test_last_run_written_when_run_returns_none():
     print("_test_last_run_written_when_run_returns_none: OK")
 
 
+def _test_ingest_history_grandparent_key_fallback():
+    """grandparentKey path form is parsed when grandparentRatingKey is absent."""
+    from datetime import datetime, timezone
+
+    class FakeEpEvent:
+        ratingKey = 9001
+        viewedAt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        grandparentKey = "/library/metadata/5555"
+        # grandparentRatingKey intentionally NOT defined as an attribute
+
+    index: dict = {}
+    count = _ingest_history([FakeEpEvent()], index)
+    assert count == 1, f"expected 1 event counted, got {count}"
+    assert 9001 in index, "episode ratingKey should be indexed"
+    assert index[9001]["plays"] == 1
+    assert 5555 in index, "grandparent id parsed from grandparentKey should be indexed"
+    assert index[5555]["plays"] == 1
+    assert index[5555]["last"] == FakeEpEvent.viewedAt
+    print("_test_ingest_history_grandparent_key_fallback: OK")
+
+
+def _test_ingest_history_no_grandparent_skipped_cleanly():
+    """Event with neither grandparentRatingKey nor parseable grandparentKey is skipped without error."""
+    from datetime import datetime, timezone
+
+    class FakeEpEventNone:
+        ratingKey = 7777
+        viewedAt = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        grandparentKey = "/unexpected/path/format"
+        # grandparentRatingKey not present; grandparentKey has no int tail
+
+    class FakeEpEventMissing:
+        ratingKey = 8888
+        viewedAt = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        # neither grandparentRatingKey nor grandparentKey present
+
+    index: dict = {}
+    count = _ingest_history([FakeEpEventNone(), FakeEpEventMissing()], index)
+    assert count == 2, f"expected 2 events counted, got {count}"
+    assert 7777 in index
+    assert 8888 in index
+    # Neither should have produced a grandparent rollup entry
+    for key in list(index.keys()):
+        assert key in (7777, 8888), f"unexpected index key {key}"
+    print("_test_ingest_history_no_grandparent_skipped_cleanly: OK")
+
+
 if __name__ == "__main__":
     if "--_test" in sys.argv:
         _test_resolve_user_share()
@@ -6470,5 +6542,7 @@ if __name__ == "__main__":
         _test_skip_disabled_when_zero()
         _test_last_run_written()
         _test_last_run_written_when_run_returns_none()
+        _test_ingest_history_grandparent_key_fallback()
+        _test_ingest_history_no_grandparent_skipped_cleanly()
         sys.exit(int(ExitCode.SUCCESS))
     sys.exit(main())


### PR DESCRIPTION
## Summary

Plex's `/status/sessions/history` endpoint returns episode events with `grandparentKey` (path form: `/library/metadata/<id>`) but always omits `grandparentRatingKey` (it is `None` on every episode event). `_ingest_history` tested `grandparentRatingKey is None` and skipped the show-level rollup, so the history index had per-episode entries only. Every `collect_series` lookup on `show.ratingKey` missed, triggering `_show_history_fallback(show.history())` for every series in the library — ~208 serial API calls, adding ~4 minutes of wait time per run.

Closes #27

## Root cause (verified on live Plex)

```
ratingKey  grandparentRatingKey  grandparentKey
123965     None                  /library/metadata/123413
123966     None                  /library/metadata/123413
...
```

`grandparentRatingKey` is always `None` from this endpoint. `grandparentKey` always holds the parseable id.

## Fix

New `_parse_grandparent_id(h)` helper:
1. Try `grandparentRatingKey` as an int (backward compatible, handles any future Plex fix).
2. On `None`, parse the trailing integer from `grandparentKey` (e.g. `/library/metadata/12345` → `12345`).
3. Guard against non-integer tails, unexpected path shapes, and absent attributes — returns `None` and the event is skipped cleanly.

`_show_history_fallback` is unchanged; it remains the true last resort for genuine ratingKey drift after rematches.

## Before / after

| | Before | After |
|---|---|---|
| `Per-show history rescued` log lines | ~208 per run | **0** |
| Extra Plex API calls per run | ~208 | **0** |
| Estimated time saved per run | ~4 minutes | — |

## Tests

- `_test_ingest_history_grandparent_key_fallback` — episode event with only `ratingKey`, `viewedAt`, and `grandparentKey` (no `grandparentRatingKey` attr) correctly produces a grandparent rollup entry with the parsed id.
- `_test_ingest_history_no_grandparent_skipped_cleanly` — events with an unparseable `grandparentKey` and with neither attribute are skipped without error; only episode-level entries appear in the index.

All 76 tests pass.

## Docs

- `AGENTS.md`: new subsection "`grandparentKey` path parsing in `_ingest_history`" documenting the endpoint omission and the fallback strategy.

## Test plan

- [x] Verified `grandparentRatingKey is None` / `grandparentKey = /library/metadata/<id>` on live Plex (Step 0)
- [x] Dry-run against live Plex: `Per-show history rescued` count = 0 (was ~208)
- [x] All 76 inline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)