### PR TITLE
feat(capacity): add capacity.unraid_api_verify_tls toggle (default true)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -751,6 +751,8 @@ by the refdbytes issue; `free` is not.
    cache whose `fsSize ≥ statvfs.free`. Requires Unraid 6.12+ and an API key
    (Settings → Management Access → API Keys). HTTPS required; use
    `https://` in `unraid_api_url` — nginx redirects HTTP with a 302.
+   The call verifies TLS by default; toggle with `capacity.unraid_api_verify_tls`
+   (default `true`; set `false` for Unraid's self-signed cert on a trusted LAN).
 2. `_try_zpool_cmd(pool_name)` — runs `zpool list -Hp -o size,alloc`. Works if
    ZFS userspace tools are present in the container. Pool name extracted from
    `/proc/mounts` via `_zfs_pool_name_for_mount`.

--- a/README.md
+++ b/README.md
@@ -801,16 +801,29 @@ capacity:
   unraid_pool_name: null   # auto-matched from hot_pool_mount; set explicitly if needed
 ```
 
-**TLS certificate:** Unraid ships a self-signed certificate by default. The API
-call verifies certificates by default, so on a stock Unraid install the call
-fails with `CERTIFICATE_VERIFY_FAILED` and capacity silently falls back to the
-next method. There are two ways to resolve this:
+**The hostname must match Unraid's configured SSL vhost — a bare IP will 404.**
+Unraid's nginx only registers the `/graphql` route on the specific hostname
+bound under **Settings → Management Access → SSL/TLS**. Hitting the box by its
+raw LAN IP (or any other hostname that resolves to it) lands on a default
+server block with no API route, returning a plain `404 Not Found` — this has
+nothing to do with certificates and `unraid_api_verify_tls` cannot fix it.
+Always set `unraid_api_url` to the exact hostname shown in that settings page
+(commonly a `*.myunraid.net` address once remote access / Connect is enabled,
+or a custom hostname if you've bound one yourself).
 
-- **Option A1 (recommended): provision a valid certificate.** Enable Unraid
-  Connect SSL under **Settings → Management Access → SSL Certificate** and point
-  `unraid_api_url` at the matching hostname. No extra config key needed.
-- **Option A2: disable verification for this call.** If you control the LAN path
-  to your Unraid server and accept the security trade-off, set
+**TLS certificate:** once you're hitting the right vhost, the next question is
+whether its certificate is trusted. Unraid's own `*.myunraid.net` hostname
+ships with a valid certificate — no extra config needed. A self-signed
+certificate (the default if you bind a custom hostname without your own valid
+cert) fails verification with `CERTIFICATE_VERIFY_FAILED`, and capacity
+silently falls back to the next method. There are two ways to resolve this:
+
+- **Option A1 (recommended): use the valid `*.myunraid.net` hostname**, or
+  provision your own valid certificate for a custom hostname under
+  **Settings → Management Access → SSL/TLS**. No extra config key needed.
+- **Option A2: disable verification for this call.** If you're bound to a
+  custom hostname with a self-signed cert, control the LAN path to your Unraid
+  server, and accept the security trade-off, set
   `capacity.unraid_api_verify_tls: false` in `tiering.yaml`.
   A WARNING is logged each run when verification is disabled so it's always
   visible in run output. This setting only affects the Unraid API capacity call —

--- a/README.md
+++ b/README.md
@@ -796,10 +796,25 @@ under **Settings → Management Access → API Keys → New Key**, then set in
 
 ```yaml
 capacity:
-  unraid_api_url: "https://192.168.1.100/graphql"  # must be https — http redirects with 302
+  unraid_api_url: "https://192.0.2.10/graphql"  # must be https — http redirects with 302
   unraid_api_key: "your-api-key-here"
   unraid_pool_name: null   # auto-matched from hot_pool_mount; set explicitly if needed
 ```
+
+**TLS certificate:** Unraid ships a self-signed certificate by default. The API
+call verifies certificates by default, so on a stock Unraid install the call
+fails with `CERTIFICATE_VERIFY_FAILED` and capacity silently falls back to the
+next method. There are two ways to resolve this:
+
+- **Option A1 (recommended): provision a valid certificate.** Enable Unraid
+  Connect SSL under **Settings → Management Access → SSL Certificate** and point
+  `unraid_api_url` at the matching hostname. No extra config key needed.
+- **Option A2: disable verification for this call.** If you control the LAN path
+  to your Unraid server and accept the security trade-off, set
+  `capacity.unraid_api_verify_tls: false` in `tiering.yaml`.
+  A WARNING is logged each run when verification is disabled so it's always
+  visible in run output. This setting only affects the Unraid API capacity call —
+  the Plex connection and all other calls are unaffected.
 
 **Option B — set `hot_pool_total_gb` in `tiering.yaml` (simpler, no API key):**
 Find your pool's total size in GB by running on the **Unraid host**. The

--- a/example.tiering.yaml
+++ b/example.tiering.yaml
@@ -293,9 +293,10 @@ capacity:
   # this option. If Plex runs on a macvlan/ipvlan-L2 network, a single macvlan/ipvlan
   # interface cannot reach the host. Use the dual-home pattern described in the README
   # "Deployment & networking" section, or switch to Option B instead.
-  unraid_api_url: null       # e.g. "https://192.168.1.100/graphql"  (must be https)
+  unraid_api_url: null       # e.g. "https://192.0.2.10/graphql"  (must be https)
   unraid_api_key: null       # API key string from the Unraid UI
   unraid_pool_name: null     # ZFS pool name (e.g. "Zfs_media"); auto-matched if null
+  unraid_api_verify_tls: true  # set false for Unraid's self-signed cert on a trusted LAN; see README
 
   # Option B — manual pool size override.
   # Advantage: no API key needed; works everywhere; requires one-time config.

--- a/tier.py
+++ b/tier.py
@@ -84,6 +84,7 @@ import math
 import os
 import re
 import shutil
+import ssl
 import subprocess
 import sys
 import traceback
@@ -284,6 +285,10 @@ DEFAULT_CONFIG = {
         # first ZFS pool returned by the API that is at least as large as
         # statvfs.free is used as the match heuristic.
         "unraid_pool_name": None,
+        # Verify TLS certificate for the Unraid Connect API call. Defaults to
+        # true (secure). Set false to skip verification for Unraid's self-signed
+        # cert on a trusted LAN — Unraid API call only, no other effect.
+        "unraid_api_verify_tls": True,
     },
     # Scheduling primitives (P4.1).
     "scheduling": {
@@ -2168,6 +2173,7 @@ def _try_unraid_api(
     pool_name_filter: Optional[str],
     hot_mount: str = "",
     free_floor_bytes: int = 0,
+    verify_tls: bool = True,
 ) -> Optional[Tuple[int, int]]:
     """Query the Unraid Connect GraphQL API for ZFS pool capacity.
 
@@ -2198,7 +2204,16 @@ def _try_unraid_api(
         )
         if api_key:
             req.add_header("x-api-key", api_key)
-        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+        ssl_ctx: Optional[ssl.SSLContext] = None
+        if not verify_tls:
+            log.warning(
+                "Capacity: Unraid API TLS verification DISABLED "
+                "(capacity.unraid_api_verify_tls=false)"
+            )
+            ssl_ctx = ssl.create_default_context()
+            ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = ssl.CERT_NONE
+        with urllib.request.urlopen(req, timeout=5, context=ssl_ctx) as resp:  # noqa: S310
             data = json.loads(resp.read())
     except Exception as exc:  # noqa: BLE001
         log.debug("Capacity: Unraid API request failed: %s", exc)
@@ -2264,6 +2279,7 @@ def _pool_usage_bytes(
     unraid_api_url: Optional[str] = None,
     unraid_api_key: Optional[str] = None,
     unraid_pool_name: Optional[str] = None,
+    verify_tls: bool = True,
 ) -> Tuple[int, int]:
     """Return (total_bytes, used_bytes) for the hot pool at mount.
 
@@ -2289,7 +2305,7 @@ def _pool_usage_bytes(
             free_floor = 0
         result = _try_unraid_api(
             unraid_api_url, unraid_api_key, unraid_pool_name,
-            hot_mount=mount, free_floor_bytes=free_floor,
+            hot_mount=mount, free_floor_bytes=free_floor, verify_tls=verify_tls,
         )
         if result is not None:
             log.debug("Capacity: hot pool via Unraid API: total=%d used=%d", *result)
@@ -2627,6 +2643,7 @@ def _apply_capacity_budget(
     unraid_api_url = (cap_cfg.get("unraid_api_url") or "").strip() or None
     unraid_api_key = (cap_cfg.get("unraid_api_key") or "").strip() or None
     unraid_pool_name = (cap_cfg.get("unraid_pool_name") or "").strip() or None
+    unraid_api_verify_tls = bool(cap_cfg.get("unraid_api_verify_tls", True))
     pool_total = pool_used = 0
     if hot_mount:
         pool_total, pool_used = _pool_usage_bytes(
@@ -2635,6 +2652,7 @@ def _apply_capacity_budget(
             unraid_api_url=unraid_api_url,
             unraid_api_key=unraid_api_key,
             unraid_pool_name=unraid_pool_name,
+            verify_tls=unraid_api_verify_tls,
         )
 
     pool_pct = (pool_used / pool_total) if pool_total else 0.0
@@ -6178,6 +6196,83 @@ def _test_capacity_unraid_api_not_configured_no_warn():
     print("_test_capacity_unraid_api_not_configured_no_warn: OK")
 
 
+def _test_unraid_api_verify_tls_false_uses_unverified_context():
+    """verify_tls=False → urlopen receives an SSLContext with CERT_NONE / check_hostname=False."""
+    import logging
+    import urllib.request as _urlreq
+    captured_kwargs: dict = {}
+    captured_warnings: list = []
+
+    class _CapturingHandler(logging.Handler):
+        def emit(self, record):
+            if record.levelno == logging.WARNING:
+                captured_warnings.append(record.getMessage())
+
+    handler = _CapturingHandler()
+    log.addHandler(handler)
+
+    def _fake_urlopen(req, timeout=None, context=None):
+        captured_kwargs["context"] = context
+        # Return a minimal JSON response so _try_unraid_api parses successfully.
+        import io
+        body = b'{"data": {"array": {"caches": []}}}'
+        return io.BytesIO(body)
+
+    orig_urlopen = _urlreq.urlopen
+    _urlreq.urlopen = _fake_urlopen
+    try:
+        _try_unraid_api(
+            "https://unraid.invalid/graphql",
+            api_key="dummy-key",
+            pool_name_filter=None,
+            verify_tls=False,
+        )
+    finally:
+        _urlreq.urlopen = orig_urlopen
+        log.removeHandler(handler)
+
+    ctx = captured_kwargs.get("context")
+    assert ctx is not None, "expected an SSLContext to be passed to urlopen, got None"
+    assert ctx.verify_mode == ssl.CERT_NONE, (
+        f"expected CERT_NONE, got {ctx.verify_mode}"
+    )
+    assert ctx.check_hostname is False, (
+        f"expected check_hostname=False, got {ctx.check_hostname}"
+    )
+    tls_warnings = [w for w in captured_warnings if "unraid_api_verify_tls=false" in w.lower()]
+    assert tls_warnings, f"expected a TLS-disabled WARNING, got: {captured_warnings}"
+    print("_test_unraid_api_verify_tls_false_uses_unverified_context: OK")
+
+
+def _test_unraid_api_verify_tls_true_verifies():
+    """verify_tls=True (default) → urlopen receives None context (stdlib default verification)."""
+    import urllib.request as _urlreq
+    captured_kwargs: dict = {}
+
+    def _fake_urlopen(req, timeout=None, context=None):
+        captured_kwargs["context"] = context
+        import io
+        body = b'{"data": {"array": {"caches": []}}}'
+        return io.BytesIO(body)
+
+    orig_urlopen = _urlreq.urlopen
+    _urlreq.urlopen = _fake_urlopen
+    try:
+        _try_unraid_api(
+            "https://unraid.invalid/graphql",
+            api_key="dummy-key",
+            pool_name_filter=None,
+            verify_tls=True,
+        )
+    finally:
+        _urlreq.urlopen = orig_urlopen
+
+    ctx = captured_kwargs.get("context")
+    # verify_tls=True → no custom context; urllib uses its own secure default.
+    assert ctx is None, f"expected no custom SSLContext, got {ctx}"
+    print("_test_unraid_api_verify_tls_true_verifies: OK")
+
+
 def _test_lock_blocks_second_instance():
     """flock held by another fd → _acquire_lock returns False (BlockingIOError)."""
     import tempfile as _tf
@@ -6462,6 +6557,8 @@ if __name__ == "__main__":
         _test_run_cap_exact_boundary()
         _test_capacity_unraid_api_failure_warns_and_falls_back()
         _test_capacity_unraid_api_not_configured_no_warn()
+        _test_unraid_api_verify_tls_false_uses_unverified_context()
+        _test_unraid_api_verify_tls_true_verifies()
         _test_lock_blocks_second_instance()
         _test_lock_stale_file_acquired()
         _test_lock_released_on_success()


### PR DESCRIPTION
## Summary

The Unraid Connect GraphQL API capacity call (`capacity.unraid_api_url`) verifies TLS certificates by default. Unraid ships a self-signed certificate, so on a stock install the call fails with `CERTIFICATE_VERIFY_FAILED` and capacity silently falls back to the next detection method. This PR adds an opt-in flag to skip verification for users on a trusted LAN path who cannot or do not want to provision a valid certificate.

## Config schema

```yaml
capacity:
  unraid_api_url: "https://192.0.2.10/graphql"
  unraid_api_key: "your-api-key-here"
  unraid_api_verify_tls: true   # set false for Unraid's self-signed cert on a trusted LAN
```

Default is `true` (secure). Existing configs without this key are unaffected.

## Behaviour

- `unraid_api_verify_tls: true` (default) — no change; urllib uses its own verifying SSL default.
- `unraid_api_verify_tls: false` — builds an `ssl.SSLContext` with `CERT_NONE` / `check_hostname=False`, passes it to `urlopen`, and emits one `log.warning(...)` per run so the disabled state is always visible in run output.
- Scoped entirely to `_try_unraid_api()` — no change to the fallback chain, Plex handling, or the webhook notifier.
- `ssl` is now imported at the top of `tier.py` with the other stdlib imports.

## Tests

- `_test_unraid_api_verify_tls_false_uses_unverified_context` — monkeypatches `urlopen`, asserts the passed context has `CERT_NONE` / `check_hostname=False` and that a TLS-disabled WARNING is emitted.
- `_test_unraid_api_verify_tls_true_verifies` — asserts no custom `SSLContext` is passed when `verify_tls=True` (urllib uses its secure default).
- All existing tests pass; full suite exits 0.

## Docs

- `README.md` — new "TLS certificate" subsection under Option A documenting the self-signed cert issue, the `unraid_api_verify_tls: false` workaround, and the recommended alternative (provision a valid cert via Unraid Connect SSL).
- `AGENTS.md` — one-line note: call verifies TLS by default; toggle with `capacity.unraid_api_verify_tls`.
- `example.tiering.yaml` — `unraid_api_verify_tls: true` added near `unraid_api_url` with a one-line comment. Example IP updated to RFC 5737 placeholder (`192.0.2.10`).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)